### PR TITLE
Feature/raise exceptions debug

### DIFF
--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -149,7 +149,7 @@ def handle_http(schema, handler, args, kwargs, logic, request_schema,
                                       for cls in allowed_exceptions):
             raise
         logging.exception(unicode(e))
-        raise HTTP500Exception('Uncaught doctor errors')
+        raise HTTP500Exception('Uncaught error in logic function')
 
 
 class FlaskResourceSchema(ResourceSchema):

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 import logging
 
 try:
-    from flask import request
-    from flask.ext import restful
+    import flask_restful
+    from flask import current_app, request
     from werkzeug.exceptions import (BadRequest, Conflict, Forbidden,
                                      HTTPException, NotFound, Unauthorized,
                                      InternalServerError)
@@ -80,7 +80,7 @@ def handle_http(schema, handler, args, kwargs, logic, request_schema,
 
     :param doctor.resource.ResourceSchema schema: Instance of a
         :class:`~doctor.resource.ResourceSchema` class.
-    :param handler: flask.ext.restful.Resource: An instance of a Flask Restful
+    :param handler: flask_restful.Resource: An instance of a Flask Restful
         resource class.
     :param tuple args: Any positional arguments passed to the wrapper method.
     :param dict kwargs: Any keyword arguments passed to the wrapper method.
@@ -142,11 +142,14 @@ def handle_http(schema, handler, args, kwargs, logic, request_schema,
     except ImmutableError as e:
         raise HTTP409Exception(unicode(e))
     except Exception as e:
+        # Always re-raise exceptions when DEBUG is enabled for development.
+        if current_app.config.get('DEBUG', False):
+            raise
         if allowed_exceptions and any(isinstance(e, cls)
                                       for cls in allowed_exceptions):
             raise
         logging.exception(unicode(e))
-        raise HTTP500Exception('Uncaught doctor error')
+        raise HTTP500Exception('Uncaught doctor errors')
 
 
 class FlaskResourceSchema(ResourceSchema):
@@ -174,7 +177,7 @@ class FlaskRouter(Router):
         if resource_schema_class is None:
             resource_schema_class = FlaskResourceSchema
         if default_base_handler is None:
-            default_base_handler = restful.Resource
+            default_base_handler = flask_restful.Resource
         super(FlaskRouter, self).__init__(
             schema_dir, resource_schema_class, default_base_handler,
             raise_response_validation_errors)

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -5,7 +5,7 @@
 import os
 
 from flask import Flask
-from flask.ext.restful import Api
+from flask_restful import Api
 from doctor.errors import NotFoundError
 from doctor.flask import FlaskRouter
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'coverage >= 3.5.2, < 4.0.0',
             'flake8 >= 2.4.0, < 3.0.0',
             'flask >= 0.10.1, < 1.0.0',
-            'flask-restful==0.2.12',
+            'flask-restful==0.3.5',
             'mock >= 1.0.1, < 2.0.0',
             'nose >= 1.3.4, < 2.0.0',
             'nose-exclude >= 0.1.9, < 1.0.0',

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -224,13 +224,23 @@ class TestFlask(TestCase):
         with self.assertRaisesRegexp(HTTP404Exception, r'404'):
             self.call_handle_http()
 
-    def test_handle_unexpected_error(self):
+    @mock.patch('doctor.flask.current_app')
+    def test_handle_unexpected_error(self, mock_current_app):
+        mock_current_app.config = {'DEBUG': False}
         self.mock_logic_exception(TypeError('bad type'))
         with self.assertRaisesRegexp(
                 HTTP500Exception, r'Uncaught doctor error'):
             self.call_handle_http()
 
-    def test_handle_unexpected_error_allowed_exceptions(self):
+        # When DEBUG is True, it should reraise the original exception
+        mock_current_app.config = {'DEBUG': True}
+        with self.assertRaisesRegexp(TypeError, 'bad type'):
+            self.call_handle_http()
+
+    @mock.patch('doctor.flask.current_app')
+    def test_handle_unexpected_error_allowed_exceptions(self, mock_current_app):
+        mock_current_app.config = {'DEBUG': False}
+
         class ExceptionalException(Exception):
             pass
         self.allowed_exceptions = [ExceptionalException]

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -229,7 +229,7 @@ class TestFlask(TestCase):
         mock_current_app.config = {'DEBUG': False}
         self.mock_logic_exception(TypeError('bad type'))
         with self.assertRaisesRegexp(
-                HTTP500Exception, r'Uncaught doctor error'):
+                HTTP500Exception, r'Uncaught error in logic function'):
             self.call_handle_http()
 
         # When DEBUG is True, it should reraise the original exception
@@ -254,5 +254,5 @@ class TestFlask(TestCase):
         # but other exceptions should still be caught
         self.mock_logic_exception(TypeError('bad type'))
         with self.assertRaisesRegexp(
-                HTTP500Exception, r'Uncaught doctor error'):
+                HTTP500Exception, r'Uncaught error in logic function'):
             self.call_handle_http()


### PR DESCRIPTION
This PR makes debugging during development easier by always re-raising the original exception from a logic function when the DEBUG config option is set to True.

This also fixes the import warning by importing flask restful appropriately and upgrades the version to the latest in the tests requirements.

`ExtDeprecationWarning: Importing flask.ext.restful is deprecated, use flask_restful instead.`

Finally this clears up the exception message when a logic function error is encountered.  The error previously made it seem like the error originated from doctor, and not the code using doctor.