### PR TITLE
Fixes a bug where the logic function wouldn't be undecorated properly.

### DIFF
--- a/doctor/router.py
+++ b/doctor/router.py
@@ -72,8 +72,9 @@ class Router(object):
             if func.__closure__:
                 for cell in func.__closure__:
                     if inspect.isfunction(cell.cell_contents):
-                        func = cell.cell_contents
-                        break
+                        if func.__name__ == cell.cell_contents.__name__:
+                            func = cell.cell_contents
+                            break
             else:
                 break
         return func

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -26,6 +26,21 @@ def dec_with_args(foo='foo', bar='bar'):
     return decorator
 
 
+def dec_with_args_one_of_which_allows_a_func(foo, bar=None):
+    """An example decorator that takes args where one is a function.
+
+    In this case, bar accepts a func which transforms foo.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if bar is not None:
+                bar(foo)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
 class RouterTestCase(TestCase):
 
     def setUp(self):
@@ -83,6 +98,14 @@ class RouterTestCase(TestCase):
         # Ensure it works with decorators that take arguments
         decorated_with_args = dec_with_args('foo1')(foobar)
         actual = self.router._undecorate_func(decorated_with_args)
+        self.assertEqual(foobar, actual)
+
+        def bar(foo):
+            return 'foo ' + foo
+
+        decorated_with_arg_takes_func = (
+            dec_with_args_one_of_which_allows_a_func('foo', bar)(foobar))
+        actual = self.router._undecorate_func(decorated_with_arg_takes_func)
         self.assertEqual(foobar, actual)
 
     def test_get_params_from_func_with_optional(self):


### PR DESCRIPTION
If the logic function was decorated and the decorator contained arguments that could also be functions we would not undecorate the function properly.  An example:

```python
def foo(params):
    return params

@audit('thing', user_func=foo)
def get_thing(auth, something=None):
   return 'thing'
```

Before the fix if you did something like the above you would get a response that said: `"'params' is a required property"`.  So doctor was using the function foo to generate the schema, rather than `get_thing`.