### PR TITLE
Fixes a bug that occurred when a logic function was decorated.

### DIFF
--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -37,7 +37,7 @@ def exec_params(call, *args, **kwargs):
     :raises TypeError:
     """
     arg_spec = getattr(call, '_argspec', None)
-    if arg_spec and not arg_spec.keywords:
+    if arg_spec:
         kwargs = {key: value for key, value in kwargs.iteritems()
                   if key in arg_spec.args}
     return call(*args, **kwargs)


### PR DESCRIPTION
This fixes issue #12.  If a logic function was decorated and you sent a
request to a doctor endpoint using the content-type application/json and
that json body had a parameter not in the signature of the logic
function, then a TypeError would occur as it would attempt to pass the
extra parameter as a **kwarg to the logic function.