### PR TITLE
Bugfix/issue12

### DIFF
--- a/doctor/resource.py
+++ b/doctor/resource.py
@@ -5,6 +5,7 @@ import jsonschema
 
 from .parsers import parse_value
 from .schema import Schema
+from .utils import undecorate_func
 
 
 class ResourceSchemaAnnotation(object):
@@ -180,7 +181,7 @@ class ResourceSchema(Schema):
         after = after if after else (lambda *args, **kwargs: None)
 
         try:
-            logic._argspec = inspect.getargspec(logic)
+            logic._argspec = inspect.getargspec(undecorate_func(logic))
         except TypeError:
             logic._argspec = inspect.getargspec(logic.__call__)
 

--- a/doctor/router.py
+++ b/doctor/router.py
@@ -1,6 +1,8 @@
 import inspect
 import os
 
+from doctor.utils import undecorate_func
+
 
 class RouterException(Exception):
     """
@@ -58,27 +60,6 @@ class Router(object):
             self.raise_response_validation_errors)
         return self.schemas[schema_file]
 
-    def _undecorate_func(self, func):
-        """Returns the original function from the decorated one.
-
-        The purpose of this function is to return the original `func` in the
-        event that it has decorators attached to it, instead of the decorated
-        function.
-
-        :param function func: The function to unwrap.
-        :returns: The unwrapped function.
-        """
-        while True:
-            if func.__closure__:
-                for cell in func.__closure__:
-                    if inspect.isfunction(cell.cell_contents):
-                        if func.__name__ == cell.cell_contents.__name__:
-                            func = cell.cell_contents
-                            break
-            else:
-                break
-        return func
-
     def _get_params_from_func(self, func, omit_args=None):
         """Gets all parameters and required parameters from the func signature.
 
@@ -91,7 +72,7 @@ class Router(object):
         :returns: A tuple containing all parameters of the function signature
             and all required args.
         """
-        argspec = inspect.getargspec(self._undecorate_func(func))
+        argspec = inspect.getargspec(undecorate_func(func))
         if argspec.defaults:
             required = argspec.args[:-len(argspec.defaults)]
         else:

--- a/doctor/router.py
+++ b/doctor/router.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 
-from doctor.utils import undecorate_func
+from .utils import undecorate_func
 
 
 class RouterException(Exception):

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 import sys
@@ -37,10 +38,32 @@ def exec_params(call, *args, **kwargs):
     :raises TypeError:
     """
     arg_spec = getattr(call, '_argspec', None)
-    if arg_spec:
+    if arg_spec and not arg_spec.keywords:
         kwargs = {key: value for key, value in kwargs.iteritems()
                   if key in arg_spec.args}
     return call(*args, **kwargs)
+
+
+def undecorate_func(func):
+    """Returns the original function from the decorated one.
+
+    The purpose of this function is to return the original `func` in the
+    event that it has decorators attached to it, instead of the decorated
+    function.
+
+    :param function func: The function to unwrap.
+    :returns: The unwrapped function.
+    """
+    while True:
+        if func.__closure__:
+            for cell in func.__closure__:
+                if inspect.isfunction(cell.cell_contents):
+                    if func.__name__ == cell.cell_contents.__name__:
+                        func = cell.cell_contents
+                        break
+        else:
+            break
+    return func
 
 
 def get_module_attr(module_filename, module_attr, namespace=None):

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -37,7 +37,7 @@ def exec_params(call, *args, **kwargs):
     :raises TypeError:
     """
     arg_spec = getattr(call, '_argspec', None)
-    if arg_spec and not arg_spec.keywords:
+    if arg_spec:
         kwargs = {key: value for key, value in kwargs.iteritems()
                   if key in arg_spec.args}
     return call(*args, **kwargs)

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -26,21 +26,6 @@ def dec_with_args(foo='foo', bar='bar'):
     return decorator
 
 
-def dec_with_args_one_of_which_allows_a_func(foo, bar=None):
-    """An example decorator that takes args where one is a function.
-
-    In this case, bar accepts a func which transforms foo.
-    """
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if bar is not None:
-                bar(foo)
-            return func(*args, **kwargs)
-        return wrapper
-    return decorator
-
-
 class RouterTestCase(TestCase):
 
     def setUp(self):
@@ -76,37 +61,6 @@ class RouterTestCase(TestCase):
         actual = router.get_schema('foobar.yaml')
         expected = 'foobar'
         self.assertEqual(expected, actual)
-
-    def test_undecorate_func(self):
-        def foobar(a, b=False):
-            pass
-
-        # No decorator just returns the function
-        actual = self.router._undecorate_func(foobar)
-        self.assertEqual(foobar, actual)
-
-        # Normal decorator with no args
-        decorated = does_nothing(foobar)
-        actual = self.router._undecorate_func(decorated)
-        self.assertEqual(foobar, actual)
-
-        # Ensure it can handle multiple decorators
-        double_decorated = does_nothing(does_nothing(foobar))
-        actual = self.router._undecorate_func(double_decorated)
-        self.assertEqual(foobar, actual)
-
-        # Ensure it works with decorators that take arguments
-        decorated_with_args = dec_with_args('foo1')(foobar)
-        actual = self.router._undecorate_func(decorated_with_args)
-        self.assertEqual(foobar, actual)
-
-        def bar(foo):
-            return 'foo ' + foo
-
-        decorated_with_arg_takes_func = (
-            dec_with_args_one_of_which_allows_a_func('foo', bar)(foobar))
-        actual = self.router._undecorate_func(decorated_with_arg_takes_func)
-        self.assertEqual(foobar, actual)
 
     def test_get_params_from_func_with_optional(self):
         def foobar(req1, req2, opt1=None, opt2=False):


### PR DESCRIPTION
This fixes a bug where if a logic function were decorated and we sent a json body request that contained parameters not in the logic function's signature it would cause a TypeError.