### PR TITLE
Performing a set operation on the decorators to filter out any

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Next release (in development)
   to make_field amd make_xref.
 - Fixed bug where extra parameters passed on json requests would cause a `TypeError`
   if the logic function used a decorator.
+- Made sure to make decorators a set when applying them to a logic function
+  when creating routes.  This is to prevent a decorator from wrapping a 
+  function twice if it's defined at the logic level and handler level when
+  creating routes.
 
 v1.1.2 (2017-02-27)
 -------------------

--- a/doctor/router.py
+++ b/doctor/router.py
@@ -153,7 +153,10 @@ class Router(object):
                 # Apply all decoraters to the `func`
                 decorators = opts.get('decorators', [])
                 decorators.extend(handler_decorators)
-                for decorator in decorators:
+                # Make decoratrs a set to remove any duplicates where a
+                # decorator may have been added at the handler level and
+                # the logic level.
+                for decorator in set(decorators):
                     func = decorator(func)
                 handler_methods_and_properites = {
                     '__name__': handler_name,

--- a/test/test_router.py
+++ b/test/test_router.py
@@ -126,6 +126,10 @@ class RouterTestCase(TestCase):
                 'handler_name': 'AnnotationHandlerV1',
 
                 'get': {
+                    # Adding a duplicate here and ensuring we don't end up
+                    # wrapping this method twice.  Instead it should perform
+                    # a set operation and only wrap the method once.
+                    'decorators': [does_nothing],
                     'logic': logic_get,
                     # Specifying a different schema file that contains `someid`
                     # for the response.  An example of overriding the schema


### PR DESCRIPTION
duplicates.

This is so we don't wrap a function twice if a decorator is defined at
the handler level and the logic level.