### PR TITLE
Don't try to parse json body on GET request.

### DIFF
--- a/doctor/constants.py
+++ b/doctor/constants.py
@@ -1,3 +1,8 @@
 #: The maximum length of a response when logging warnings for invalid response
 #: schemas.
 MAX_RESPONSE_LENGTH = 300
+
+#: HTTP methods that are allowed to have a JSON body.  Technically all HTTP
+#: methods are allowed to have a body, but some like GET/DELETE have no
+#: contextual meaning server side, so should not be used.
+HTTP_METHODS_WITH_JSON_BODY = ('PATCH', 'POST', 'PUT')

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover
     raise ImportError('You must install flask to use the '
                       'doctor.flask module.')
 
-from .constants import MAX_RESPONSE_LENGTH
+from .constants import HTTP_METHODS_WITH_JSON_BODY, MAX_RESPONSE_LENGTH
 from .errors import (ForbiddenError, ImmutableError, InvalidValueError,
                      ParseError, NotFoundError, SchemaValidationError,
                      UnauthorizedError)
@@ -102,7 +102,8 @@ def handle_http(schema, handler, args, kwargs, logic, request_schema,
             # mimetype is just the content-type, where as content_type can
             # contain encoding, charset, and language information.  e.g.
             # `Content-Type: application/json; charset=UTF8`
-            if request.mimetype == 'application/json':
+            if (request.mimetype == 'application/json' and
+                    request.method in HTTP_METHODS_WITH_JSON_BODY):
                 # This is a proper typed JSON request. The parameters will be
                 # encoded into the request body as a JSON blob.
                 params = request.json

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -61,6 +61,7 @@ class TestFlask(TestCase):
                            self.allowed_exceptions)
 
     def mock_logic_exception(self, exception):
+        self.mock_request.method = 'POST'
         self.mock_request.content_type = 'application/json; charset=UTF8'
         self.mock_request.mimetype = 'application/json'
         self.mock_request.json = {'a': 'foo', 'b': 1}
@@ -90,6 +91,16 @@ class TestFlask(TestCase):
         self.assertEqual(result, ({'foo': 1}, 201))
         self.assertEqual(self.mock_logic.call_args_list,
                          [mock.call(10, x=20, y=30, a='foo', b=2)])
+
+    def test_handle_http_unsupported_http_method_with_body(self):
+        self.mock_request.method = 'GET'
+        self.mock_request.content_type = 'application/json; charset=UTF8'
+        self.mock_request.mimetype = 'application/json'
+        self.mock_request.json = None
+        self.mock_request.values = {'a': 'foo', 'b': '1'}
+        result = self.call_handle_http((10,))
+        expected = ({'foo': 1}, 200)
+        self.assertEqual(expected, result)
 
     def test_handle_http_with_params(self):
         self.mock_request.method = 'DELETE'


### PR DESCRIPTION
Technically JSON bodies are allowed on GET/DELETE requests, but
according to the HTTP spec, they have no contextual meaning and
shouldn't alter the response.  Because of this the body can't be parsed
in flask.  If this happens we instead try to parse parameters from the
query string and form.