### PR TITLE
Fixes issue 18.

### DIFF
--- a/doctor/router.py
+++ b/doctor/router.py
@@ -149,7 +149,8 @@ class Router(object):
                 func = http_func(
                     opts['logic'], params=params, required=required,
                     response=opts.get('response'), title=opts.get('title'),
-                    allowed_exceptions=opts.get('allowed_exceptions'))
+                    allowed_exceptions=opts.get('allowed_exceptions'),
+                    omit_args=omit_args)
                 # Apply all decoraters to the `func`
                 decorators = opts.get('decorators', [])
                 decorators.extend(handler_decorators)

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
             'flake8 >= 2.4.0, < 3.0.0',
             'flask >= 0.10.1, < 1.0.0',
             'flask-restful==0.3.5',
+            'Flask-Testing==0.6.2',
             'mock >= 1.0.1, < 2.0.0',
             'nose >= 1.3.4, < 2.0.0',
             'nose-exclude >= 0.1.9, < 1.0.0',

--- a/test/base.py
+++ b/test/base.py
@@ -1,4 +1,10 @@
+import os
 import unittest
+
+import flask_restful
+import flask_testing
+from doctor.flask import FlaskResourceSchema, FlaskRouter
+from flask import Flask
 
 
 class TestCase(unittest.TestCase):
@@ -8,3 +14,62 @@ class TestCase(unittest.TestCase):
     def shortDescription(self):
         # Do not show first line of the docstring as a test description
         return None
+
+
+class FlaskTestCase(flask_testing.TestCase):
+
+    """
+    This test case base class is used for integration tests with flask
+    and doctor.
+    """
+
+    #: Displays the full diff on failure.
+    maxDiff = None
+
+    def shortDescription(self):
+        # Do not show first line of the docstring as a test description
+        return None
+
+    def get_routes(self):
+        """Gets the routes for the app.
+
+        This should return a tuple of tuples.  Each tuple contains the
+        route as a string and the instnace of a resource to route to.  e.g.
+
+        (
+            ('/some/url/', doctor.router.Handler1),
+        )
+
+        This method can be overridden in subclasses to change the routes and
+        add new ones.
+
+        :returns: The tuple described above.
+        """
+        def logic_func(annotation_id, url=None):
+            return (annotation_id, url)
+
+        schema_dir = os.path.join(os.path.dirname(__file__), 'schema')
+        router = FlaskRouter(schema_dir, FlaskResourceSchema)
+        return router.create_routes('Test', 'annotation.yaml', {
+            '/test/': {
+                'get': {
+                    'logic': logic_func,
+                },
+            },
+        })
+
+    def create_app(self):
+        """This method creates the flask app.
+
+        This is required to be implemented by flask_restful.
+
+        :returns: Flask application instance.
+        """
+        app = Flask('test')
+        app.config['TESTING'] = True
+
+        api = flask_restful.Api(app)
+        for url, handler in self.get_routes():
+            api.add_resource(handler, url)
+
+        return api.app

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -320,7 +320,8 @@ class TestResourceSchema(TestCase):
                 [mock.call(schema, s.logic, method.upper(), request=s.request,
                            response=s.response, params=s.params,
                            required=s.required, title=s.title, before=None,
-                           after=None, allowed_exceptions=None)])
+                           after=None, allowed_exceptions=None,
+                           omit_args=None)])
 
 
 class TestResourceSchemaAnnotation(TestCase):

--- a/test/test_router_integration.py
+++ b/test/test_router_integration.py
@@ -1,0 +1,56 @@
+import os
+from functools import wraps
+
+from doctor.flask import FlaskResourceSchema, FlaskRouter
+
+from .base import FlaskTestCase
+
+
+def adds_positional_arg_to_func(arg=1):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(arg, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+@adds_positional_arg_to_func(55)
+def logic_func(pos_arg, annotation_id, name=None):
+    return {
+        'annotation_id': annotation_id,
+        'name': name,
+        'pos_arg': pos_arg,
+    }
+
+
+class RouterIntegrationTestCase(FlaskTestCase):
+
+    def get_routes(self):
+        schema_dir = os.path.join(os.path.dirname(__file__), 'schema')
+        router = FlaskRouter(schema_dir, FlaskResourceSchema)
+        return router.create_routes('Test', 'annotation.yaml', {
+            '/test/': {
+                'get': {
+                    'logic': logic_func,
+                    'omit_args': ['pos_arg'],
+                },
+            },
+        })
+
+    def test_decorated_logic_func_passes_arg_to_func(self):
+        """
+        This test verifies everything works properly if our logic function
+        is decorated and the decorator passes an extra positional argument to
+        it.  This was broken in v1.1.3 as it would cause a 400 saying that
+        `pos_arg` is required as a request parameter since it was not taking
+        into accout `omit_args` and just determining required arguments based
+        on the function signature's non-keyword arguments.
+        """
+        response = self.client.get('/test/', query_string={'annotation_id': 1})
+        expected = {
+            'annotation_id': 1,
+            'name': None,
+            'pos_arg': 55,
+        }
+        self.assertEqual(expected, response.json)


### PR DESCRIPTION
This fixes a bug introducded in v1.1.3.  This bug would only occur if a
logic function was decorated and that decorator passed a positional
argument to the logic function.  Doctor would think the positional
argument passed by the decorator was a required request parameter even
if it was specified to be omitted in the router using `omit_args`.