### PR TITLE
Fix more things for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.6"
 install: pip install tox-travis
 script: tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import absolute_import
 import sys
 import os
 
@@ -150,10 +151,6 @@ html_static_path = ['_static']
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
 
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-html_use_smartypants = True
-
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 
@@ -270,7 +267,7 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 
-from .flask_harness import CustomFlaskHarness
+from docs.flask_harness import CustomFlaskHarness
 
 
 autoflask_harness = CustomFlaskHarness('examples/flask/app.py',

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -11,8 +11,8 @@ import six
 from doctor.errors import ParseError
 
 
-_bracket_strings = ('[', b'[')
-_brace_strings = ('{', b'{')
+_bracket_strings = ('[', ord('['))
+_brace_strings = ('{', ord('{'))
 _false_strings = ('false', b'false')
 _true_strings = ('true', b'true')
 

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -11,6 +11,12 @@ import six
 from doctor.errors import ParseError
 
 
+_bracket_strings = ('[', b'[')
+_brace_strings = ('{', b'{')
+_false_strings = ('false', b'false')
+_true_strings = ('true', b'true')
+
+
 def _parse_array(value):
     """Coerce value into an list.
 
@@ -20,7 +26,7 @@ def _parse_array(value):
         be parsed as JSON.
     """
     value = value.lstrip()
-    if not value or value[0] != '[':
+    if not value or value[0] not in _bracket_strings:
         return None
     return json.loads(value)
 
@@ -32,9 +38,9 @@ def _parse_boolean(value):
     :returns: bool or None if the value is not a boolean string.
     """
     value = value.lower()
-    if value == 'true':
+    if value in _true_strings:
         return True
-    elif value == 'false':
+    elif value in _false_strings:
         return False
     else:
         return None
@@ -49,7 +55,7 @@ def _parse_object(value):
         be parsed as JSON.
     """
     value = value.lstrip()
-    if not value or value[0] != '{':
+    if not value or value[0] not in _brace_strings:
         return None
     return json.loads(value)
 
@@ -63,10 +69,10 @@ def _parse_string(value):
     :param str value: Value to parse.
     :returns: str
     """
-    if isinstance(value, six.text_type):
-        return value.encode('utf-8')
-    else:
-        return value
+    if (not isinstance(value, six.string_types) and
+            isinstance(value, six.binary_type)):
+        return value.decode('utf-8')
+    return value
 
 
 _parser_funcs = (('boolean', _parse_boolean),

--- a/doctor/schema.py
+++ b/doctor/schema.py
@@ -62,7 +62,7 @@ class SchemaRefResolver(jsonschema.RefResolver):
         except jsonschema.RefResolutionError as e:
             # Failed to find a ref. Make the error a bit prettier so we can
             # figure out where it came from.
-            message = e.message
+            message = e.args[0]
             if self._scopes_stack:
                 message = '{} (from {})'.format(
                     message, self._format_stack(self._scopes_stack))
@@ -190,8 +190,8 @@ class Schema(object):
                         key = error.path[0]
                     except IndexError:
                         key = '_other'
-                    errors[key] = error.message
-                raise SchemaValidationError(e.message, errors=errors)
+                    errors[key] = error.args[0]
+                raise SchemaValidationError(e.args[0], errors=errors)
         return value
 
     def validate_json(self, json_value, validator):

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -103,3 +103,5 @@ for route, resource in routes:
 
 if __name__ == '__main__':
     app.run(debug=True)
+
+# -- mark-end

--- a/test/test_docs_base.py
+++ b/test/test_docs_base.py
@@ -289,13 +289,14 @@ class TestDocsBase(TestCase):
             'type': 'integer',
             'description': 'An integer and we are missing the example'
         }
-        with self.assertRaises(SchemaError) as cm:
+        expected_message = (
+            r"Error resolving #example from \{'type': 'integer', "
+            r"'description': 'An integer and we are missing the "
+            r"example'\} for property `foobar`\. Unresolvable JSON "
+            r"pointer: u?'example' \(from \)"
+        )
+        with self.assertRaisesRegexp(SchemaError, expected_message):
             base.get_example_value(property_schema, self.schema, 'foobar')
-        expected = ("Error resolving #example from {'type': 'integer', "
-                    "'description': 'An integer and we are missing the "
-                    "example'} for property `foobar`. Unresolvable JSON "
-                    "pointer: u'example' (from )")
-        self.assertEqual(expected, cm.exception.message)
 
     def test_get_example_lines_json(self):
         """Tests an example when the response is valid JSON."""

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -35,7 +35,7 @@ class TestParsers(TestCase):
             ('{"a": 1}', ['object'], {'a': 1}),
             ('foo', ['string'], 'foo'),
             ('"foo"', ['string'], '"foo"'),
-            (u'foø', ['string'], u'foø'.encode('utf-8')),
+            (u'foø', ['string'], u'foø'),
 
             # ambiguous test cases
             ('', ['string', 'null'], None),

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -132,12 +132,12 @@ class TestSchemaRefResolver(TestCase):
 
     def test_resolve_error(self):
         with self.assertRaisesRegexp(
-                SchemaError, r"Unresolvable JSON pointer: u'invalid_ref'"):
+                SchemaError, r"Unresolvable JSON pointer: u?'invalid_ref'"):
             self.resolver.resolve('#/invalid_ref')
 
     def test_resolve_error_chain(self):
         expected_message = (
-            r"Unresolvable JSON pointer: u'invalid_ref_chain_3' \(from "
+            r"Unresolvable JSON pointer: u?'invalid_ref_chain_3' \(from "
             r"/ => /#/invalid_ref_chain_1 => /#/invalid_ref_chain_2\)")
         with self.assertRaisesRegexp(SchemaError, expected_message):
             self.resolver.resolve('#/invalid_ref_chain_1')


### PR DESCRIPTION
It turns out Python 3 tests weren't running in Travis, and a local misconfiguration issue was causing the Python 3 tests to be run using Python 2 instead, so not all the Python 3 things were fixed in 1.2.0.

One significant change in this release is that unicode strings aren't encoded as UTF-8 anymore. I think that makes the most sense for Python 3, and this way both Python 2 and 3 work the same way. But if we want to keep strict compatibility with the way things were working in Python 2 before, we could encode to UTF-8 for only Python 2 instead...