### PR TITLE
[issue-38] Fixed some deprecation warnings when running python 3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info
 *.pyc
 .noseids
+/.cache
 /.coverage
 /.noseids
 /.tox

--- a/doctor/router.py
+++ b/doctor/router.py
@@ -1,6 +1,8 @@
 import inspect
 import os
 
+import six
+
 from .utils import undecorate_func
 
 
@@ -72,7 +74,9 @@ class Router(object):
         :returns: A tuple containing all parameters of the function signature
             and all required args.
         """
-        argspec = inspect.getargspec(undecorate_func(func))
+        getargspec_func = (
+            inspect.getargspec if six.PY2 else inspect.getfullargspec)
+        argspec = getargspec_func(undecorate_func(func))
         if argspec.defaults:
             required = argspec.args[:-len(argspec.defaults)]
         else:

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -39,7 +39,7 @@ def exec_params(call, *args, **kwargs):
     :raises TypeError:
     """
     arg_spec = getattr(call, '_argspec', None)
-    if arg_spec and not arg_spec.keywords:
+    if arg_spec and not (arg_spec.keywords if six.PY2 else arg_spec.varkw):
         kwargs = {key: value for key, value in kwargs.items()
                   if key in arg_spec.args}
     return call(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,7 @@ setup(
             'flask-restful==0.3.6',
             'Flask-Testing==0.6.2',
             'mock >= 2.0.0, < 3.0.0',
-            'nose >= 1.3.7, < 2.0.0',
-            'nose-exclude >= 0.5.0, < 1.0.0',
+            'pytest >= 3.3.2, < 4.0.0',
         ],
     },
 )

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -1,5 +1,7 @@
 from functools import wraps
+
 import mock
+import six
 
 from doctor.resource import ResourceSchema, ResourceSchemaAnnotation
 from doctor.flask import handle_http
@@ -220,7 +222,7 @@ class TestResourceSchema(TestCase):
         spec = handler._argspec
         self.assertEqual(['a', 'b'], spec.args)
         self.assertIsNone(spec.varargs)
-        self.assertIsNone(spec.keywords)
+        self.assertIsNone(spec.keywords if six.PY2 else spec.varkw)
         self.assertEqual((1,), spec.defaults)
 
         handler = schema._create_http_method(
@@ -229,7 +231,7 @@ class TestResourceSchema(TestCase):
         spec = handler._argspec
         self.assertEqual(['a', 'b'], spec.args)
         self.assertIsNone(spec.varargs)
-        self.assertEqual('kwargs', spec.keywords)
+        self.assertEqual('kwargs', spec.keywords if six.PY2 else spec.varkw)
         self.assertEqual((1,), spec.defaults)
 
         # This caused issue #12 on github.
@@ -239,7 +241,7 @@ class TestResourceSchema(TestCase):
         spec = handler._argspec
         self.assertEqual(['a', 'b'], spec.args)
         self.assertIsNone(spec.varargs)
-        self.assertIsNone(spec.keywords)
+        self.assertIsNone(spec.keywords if six.PY2 else spec.varkw)
         self.assertEqual((1,), spec.defaults)
 
         handler = schema._create_http_method(
@@ -249,7 +251,7 @@ class TestResourceSchema(TestCase):
         spec = handler._argspec
         self.assertEqual(['a', 'b'], spec.args)
         self.assertIsNone(spec.varargs)
-        self.assertEqual('kwargs', spec.keywords)
+        self.assertEqual('kwargs', spec.keywords if six.PY2 else spec.varkw)
         self.assertEqual((1,), spec.defaults)
 
     def test_before_after_callables(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,12 +3,19 @@ import os
 from functools import wraps
 
 import mock
+import six
 
 from .base import TestCase
 
 from doctor.utils import (
     exec_params, get_description_lines, get_module_attr, nested_set,
     undecorate_func)
+
+
+if six.PY2:
+    getargspec_func = inspect.getargspec
+else:
+    getargspec_func = inspect.getfullargspec
 
 
 def does_nothing(func):
@@ -49,7 +56,7 @@ class TestUtils(TestCase):
     def test_exec_params_function(self):
         def logic(a, b, c=None):
             return a+1, b+1, c
-        logic._argspec = inspect.getargspec(logic)
+        logic._argspec = getargspec_func(logic)
         kwargs = {'c': 1, 'd': 'a'}
         args = (1, 2)
         a, b, c = exec_params(logic, *args, **kwargs)
@@ -65,7 +72,7 @@ class TestUtils(TestCase):
             def __call__(self, a, b, c=None):
                 return a+1, b+1, c
         logic = Foo()
-        logic._argspec = inspect.getargspec(logic.__call__)
+        logic._argspec = getargspec_func(logic.__call__)
         a, b, c = exec_params(logic, *args, **kwargs)
         self.assertEqual(a, args[0]+1)
         self.assertEqual(b, args[1]+1)
@@ -74,7 +81,7 @@ class TestUtils(TestCase):
     def test_exec_params_args_only(self):
         def logic(a, b, c):
             return a+1, b+1, c
-        logic._argspec = inspect.getargspec(logic)
+        logic._argspec = getargspec_func(logic)
         kwargs = {'d': 1, 'e': 2}
         args = (1, 2, 3)
         a, b, c = exec_params(logic, *args, **kwargs)
@@ -85,7 +92,7 @@ class TestUtils(TestCase):
     def test_exec_params_kwargs_only(self):
         def logic(a=1, b=2, c=3):
             return a+1, b+1, c
-        logic._argspec = inspect.getargspec(logic)
+        logic._argspec = getargspec_func(logic)
         kwargs = {'d': 1, 'e': 2}
         args = (1, 2, 3)
         a, b, c = exec_params(logic, *args, **kwargs)
@@ -109,7 +116,7 @@ class TestUtils(TestCase):
         def logic(a, b=2, c=3, **kwargs):
             return (a, b, c, kwargs)
 
-        logic._argspec = inspect.getargspec(logic)
+        logic._argspec = getargspec_func(logic)
         kwargs = {'c': 3, 'e': 2}
         args = (1, 2)
         actual = exec_params(logic, *args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     PYTHONHASHSEED = 0
 commands =
     pip install --quiet --editable .[docs,tests]
-    coverage run {envbindir}/nosetests {posargs}
+    coverage run {envbindir}/pytest {posargs}
     coverage report
     flake8
     py36: sphinx-build -q -b html docs docs/_build/html


### PR DESCRIPTION
inspect.getargspec is deprecated as of python 3.0. `inspect.getfullargspec` replaces it.  It renames the `defaults` attribute to `varkw` in the return value of `inspect.getfullargspec`.  I also switched to pytest.