### PR TITLE
Feature/issue 42 - Add routing code to work with doctor python types

### DIFF
--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import copy
 import logging
+from typing import Callable, Dict, List, Tuple, Union
+
 
 import six
 try:
@@ -28,6 +30,8 @@ STATUS_CODE_MAP = {
     'POST': 201,
     'DELETE': 204,
 }
+
+ListOrNone = Union[List, None]
 
 
 class SchematicHTTPException(HTTPException):
@@ -71,7 +75,8 @@ class HTTP500Exception(SchematicHTTPException, InternalServerError):
     pass
 
 
-def handle_http_v3(handler, args, kwargs, logic, allowed_exceptions=None):
+def handle_http_v3(handler: flask_restful.Resource, args: Tuple, kwargs: Dict,
+                   logic: Callable, allowed_exceptions: ListOrNone=None):
     """Handle a Flask HTTP request
 
     @TODO:

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -17,7 +17,7 @@ except ImportError:  # pragma: no cover
 from .constants import HTTP_METHODS_WITH_JSON_BODY, MAX_RESPONSE_LENGTH
 from .errors import (ForbiddenError, ImmutableError, InvalidValueError,
                      ParseError, NotFoundError, SchemaValidationError,
-                     UnauthorizedError)
+                     TypeSystemError, UnauthorizedError)
 from .response import Response
 from .resource import ResourceSchema
 from .router import Router
@@ -69,6 +69,78 @@ class HTTP409Exception(SchematicHTTPException, Conflict):
 
 class HTTP500Exception(SchematicHTTPException, InternalServerError):
     pass
+
+
+def handle_http_v3(handler, args, kwargs, logic, allowed_exceptions=None):
+    """Handle a Flask HTTP request
+
+    @TODO:
+        - allowed_exceptions
+        - response validation
+
+    :param handler: flask_restful.Resource: An instance of a Flask Restful
+        resource class.
+    :param tuple args: Any positional arguments passed to the wrapper method.
+    :param dict kwargs: Any keyword arguments passed to the wrapper method.
+    :param callable logic: The callable to invoke to actually perform the
+        business logic for this request.
+    :param allowed_exceptions: If specified, these exception classes will be
+        re-raised instead of turning them into 500 errors.
+    :type allowed_exceptions: list(class) or None
+    """
+    try:
+        # We are checking mimetype here instead of content_type because
+        # mimetype is just the content-type, where as content_type can
+        # contain encoding, charset, and language information.  e.g.
+        # `Content-Type: application/json; charset=UTF8`
+        if (request.mimetype == 'application/json' and
+                request.method in HTTP_METHODS_WITH_JSON_BODY):
+            # This is a proper typed JSON request. The parameters will be
+            # encoded into the request body as a JSON blob.
+            request_params = request.json
+        else:
+            # Try to parse things from normal HTTP parameters
+            request_params = request.values
+        # Filter out any params not part of the logic signature.
+        all_params = logic._doctor_params.all
+        params = {k: v for k, v in request_params.items() if k in all_params}
+        params.update(**kwargs)
+
+        # Validate and coerce parameters to the appropriate types.
+        for required in logic._doctor_params.required:
+            if required not in params:
+                raise InvalidValueError(f'{required} is required.')
+        sig = logic._doctor_signature
+        for name, value in params.items():
+            annotation = sig.parameters[name].annotation
+            params[name] = annotation(value)
+
+        response = logic(*args, **params)
+        # @TODO: Response type validation
+        if isinstance(response, Response):
+            return (response.content, STATUS_CODE_MAP.get(request.method, 200),
+                    response.headers)
+        return response, STATUS_CODE_MAP.get(request.method, 200)
+    except (InvalidValueError, TypeSystemError) as e:
+        errors = getattr(e, 'errors', None)
+        raise HTTP400Exception(e, errobj=errors)
+    except UnauthorizedError as e:
+        raise HTTP401Exception(e)
+    except ForbiddenError as e:
+        raise HTTP403Exception(e)
+    except NotFoundError as e:
+        raise HTTP404Exception(e)
+    except ImmutableError as e:
+        raise HTTP409Exception(e)
+    except Exception as e:
+        # Always re-raise exceptions when DEBUG is enabled for development.
+        if current_app.config.get('DEBUG', False):
+            raise
+        if allowed_exceptions and any(isinstance(e, cls)
+                                      for cls in allowed_exceptions):
+            raise
+        logging.exception(e)
+        raise HTTP500Exception('Uncaught error in logic function')
 
 
 def handle_http(schema, handler, args, kwargs, logic, request_schema,

--- a/doctor/router_v3.py
+++ b/doctor/router_v3.py
@@ -1,0 +1,110 @@
+import functools
+import inspect
+from collections import namedtuple
+from typing import Any, Callable, Dict, Tuple
+
+import flask_restful
+
+from doctor.flask import handle_http_v3
+
+
+def delete(func: Callable) -> Dict[str, Any]:
+    """Returns a dict with required args to create a DELETE route.
+
+    :param func: The logic function that should be called.
+    :returns: dict
+    """
+    return {
+        'logic': func,
+        'http_method': 'delete',
+    }
+
+
+def get(func: Callable) -> Dict[str, Any]:
+    """Returns a dict with required args to create a GET route.
+
+    :param func: The logic function that should be called.
+    :returns: dict
+    """
+    return {
+        'logic': func,
+        'http_method': 'get',
+    }
+
+
+def post(func: Callable) -> Dict[str, Any]:
+    """Returns a dict with required args to create a POST route.
+
+    :param func: The logic function that should be called.
+    :returns: dict
+    """
+    return {
+        'logic': func,
+        'http_method': 'post',
+    }
+
+
+def put(func: Callable) -> Dict[str, Any]:
+    """Returns a dict with required args to create a PUT route.
+
+    :param func: The logic function that should be called.
+    :returns: dict
+    """
+    return {
+        'logic': func,
+        'http_method': 'put',
+    }
+
+
+def get_params_from_func(func):
+    Params = namedtuple('Params', ['all', 'optional', 'required'])
+    s = func._doctor_signature
+    required = [key for key, p in s.parameters.items() if p.default == p.empty]
+    optional = [key for key, p in s.parameters.items() if p.default != p.empty]
+    all_params = [key for key in s.parameters.keys()]
+    return Params(all_params, optional, required)
+
+
+def create_http_method(logic, http_method):
+    @functools.wraps(logic)
+    def fn(handler, *args, **kwargs):
+        return handle_http_v3(handler, args, kwargs, logic)
+    return fn
+
+
+def create_routes(routes: Tuple[str, Tuple]):
+    """Creates routes.
+
+    :param routes: A tuple containing the route and another tuple with
+        all http methods allowed for the route.
+    :returns:
+    """
+    created_routes = []
+    for route, methods in routes:
+        handler = None
+        for method in methods:
+            logic = method['logic']
+            http_method = method['http_method']
+            logic._doctor_signature = inspect.signature(logic)
+            params = get_params_from_func(logic)
+            logic._doctor_params = params
+            http_func = create_http_method(logic, http_method)
+            handler_name = logic.__name__
+            handler_methods_and_properties = {
+                '__name__': handler_name,
+                http_method: http_func,
+            }
+            if handler is None:
+                handler = type(
+                    handler_name, (flask_restful.Resource,),
+                    handler_methods_and_properties)
+            else:
+                setattr(handler, http_method, http_func)
+                # This is specific to Flask.  Its MethodView class
+                # initializes the methods attribute in __new__ so we
+                # need to add all the other http methods we are defining
+                # on the handler after it gets created by type.
+                if hasattr(handler, 'methods'):
+                    handler.methods.append(http_method.upper())
+        created_routes.append((route, handler))
+    return created_routes

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -2,38 +2,56 @@
 # generate documentation from this file. You're probably better served reading
 # the actual documentation (see Using in Flask in the docs).
 
-import os
-
 from flask import Flask
 from flask_restful import Api
 from doctor.errors import NotFoundError
-from doctor.flask import FlaskRouter
+from doctor.router_v3 import create_routes, get, post, put, delete
+from doctor.types import array, boolean, integer, string, Object
+
+# -- mark-types
+
+Body = string('Note body')
+Done = boolean('Marks if a note is done or not.')
+NoteId = integer('Note ID')
+Status = string('API status')
+
+
+class Note(Object):
+    description = 'A note object'
+    properties = {
+        'note_id': NoteId,
+        'body': Body,
+        'done': Done,
+    }
+
+
+Notes = array('Array of notes', items=Note)
 
 # -- mark-logic
 
 note = {'note_id': 1, 'body': 'Example body', 'done': False}
 
 
-def get_note(note_id):
+def get_note(note_id: NoteId) -> Note:
     """Get a note by ID."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
     return note
 
 
-def get_notes():
+def get_notes() -> Notes:
     """Get a list of notes."""
     return [note]
 
 
-def create_note(body, done=False):
+def create_note(body: Body, done: Done=False) -> Note:
     """Create a new note."""
     return {'note_id': 2,
             'body': body,
             'done': done}
 
 
-def update_note(note_id, body=None, done=None):
+def update_note(note_id: NoteId, body: Body=None, done: Done=None) -> Note:
     """Update an existing note."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
@@ -45,60 +63,34 @@ def update_note(note_id, body=None, done=None):
     return new_note
 
 
-def delete_note(note_id):
+def delete_note(note_id: NoteId):
     """Delete an existing note."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
 
 
-def status():
+def status() -> Status:
     return 'Notes API v1.0.0'
 
 
 # -- mark-app
-router = FlaskRouter(os.path.abspath('..'))
-routes = router.create_routes('API Status', 'schema.yaml', {
-    '/': {
-        'get': {
-            'logic': status,
-        },
-    },
-})
-routes.extend(router.create_routes('Notes (v1)', 'schema.yaml', {
-    '/note/': {
-        'get': {
-            'additional_args': {
-                'optional': ['limit', 'offset'],
-                'required': ['auth'],
-            },
-            'logic': get_notes,
-            'response': 'notes',
-            'title': 'Retrieve List',
-        },
-        'post': {
-            'logic': create_note,
-            'response': 'note',
-        },
-    },
-    '/note/<int:note_id>/': {
-        'delete': {
-            'logic': delete_note,
-        },
-        'get': {
-            'logic': get_note,
-            'response': 'note',
-        },
-        'put': {
-            'logic': update_note,
-            'response': 'note',
-        },
-    },
-}))
+
+routes = (
+    ('/', (
+        get(status),)),
+    ('/note/', (
+        get(get_notes),
+        post(create_note))),
+    ('/note/<int:note_id>/', (
+        delete(delete_note),
+        get(get_note),
+        put(update_note))),
+)
 
 app = Flask('Doctor example')
 
 api = Api(app)
-for route, resource in routes:
+for route, resource in create_routes(routes):
     api.add_resource(resource, route)
 
 if __name__ == '__main__':

--- a/examples/flask/app_v3.py
+++ b/examples/flask/app_v3.py
@@ -2,38 +2,56 @@
 # generate documentation from this file. You're probably better served reading
 # the actual documentation (see Using in Flask in the docs).
 
-import os
-
 from flask import Flask
 from flask_restful import Api
 from doctor.errors import NotFoundError
-from doctor.flask import FlaskRouter
+from doctor.router_v3 import create_routes, get, post, put, delete
+from doctor.types import array, boolean, integer, string, Object
+
+# -- mark-types
+
+Body = string('Note body')
+Done = boolean('Marks if a note is done or not.')
+NoteId = integer('Note ID')
+Status = string('API status')
+
+
+class Note(Object):
+    description = 'A note object'
+    properties = {
+        'note_id': NoteId,
+        'body': Body,
+        'done': Done,
+    }
+
+
+Notes = array('Array of notes', items=Note)
 
 # -- mark-logic
 
 note = {'note_id': 1, 'body': 'Example body', 'done': False}
 
 
-def get_note(note_id):
+def get_note(note_id: NoteId) -> Note:
     """Get a note by ID."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
     return note
 
 
-def get_notes():
+def get_notes() -> Notes:
     """Get a list of notes."""
     return [note]
 
 
-def create_note(body, done=False):
+def create_note(body: Body, done: Done=False) -> Note:
     """Create a new note."""
     return {'note_id': 2,
             'body': body,
             'done': done}
 
 
-def update_note(note_id, body=None, done=None):
+def update_note(note_id: NoteId, body: Body=None, done: Done=None) -> Note:
     """Update an existing note."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
@@ -45,60 +63,34 @@ def update_note(note_id, body=None, done=None):
     return new_note
 
 
-def delete_note(note_id):
+def delete_note(note_id: NoteId):
     """Delete an existing note."""
     if note_id != 1:
         raise NotFoundError('Note does not exist')
 
 
-def status():
+def status() -> Status:
     return 'Notes API v1.0.0'
 
 
 # -- mark-app
-router = FlaskRouter(os.path.abspath('..'))
-routes = router.create_routes('API Status', 'schema.yaml', {
-    '/': {
-        'get': {
-            'logic': status,
-        },
-    },
-})
-routes.extend(router.create_routes('Notes (v1)', 'schema.yaml', {
-    '/note/': {
-        'get': {
-            'additional_args': {
-                'optional': ['limit', 'offset'],
-                'required': ['auth'],
-            },
-            'logic': get_notes,
-            'response': 'notes',
-            'title': 'Retrieve List',
-        },
-        'post': {
-            'logic': create_note,
-            'response': 'note',
-        },
-    },
-    '/note/<int:note_id>/': {
-        'delete': {
-            'logic': delete_note,
-        },
-        'get': {
-            'logic': get_note,
-            'response': 'note',
-        },
-        'put': {
-            'logic': update_note,
-            'response': 'note',
-        },
-    },
-}))
+
+routes = (
+    ('/', (
+        get(status),)),
+    ('/note/', (
+        get(get_notes),
+        post(create_note))),
+    ('/note/<int:note_id>/', (
+        delete(delete_note),
+        get(get_note),
+        put(update_note))),
+)
 
 app = Flask('Doctor example')
 
 api = Api(app)
-for route, resource in routes:
+for route, resource in create_routes(routes):
     api.add_resource(resource, route)
 
 if __name__ == '__main__':

--- a/test/test_flask_v3.py
+++ b/test/test_flask_v3.py
@@ -1,0 +1,109 @@
+import inspect
+from unittest import mock
+
+import pytest
+
+from doctor.flask import handle_http_v3, HTTP400Exception
+from doctor.response import Response
+from doctor.router_v3 import get_params_from_func
+from doctor.types import integer, boolean, Object, new_type
+
+
+ItemId = integer('item id', minimum=1)
+Item = new_type(Object, 'item', properties={'item_id': ItemId})
+IncludeDeleted = boolean('indicates if deleted items should be included.')
+IsDeleted = boolean('Indicates if the item should be marked as deleted')
+
+
+def get_item(item_id: ItemId, include_deleted: IncludeDeleted=False) -> Item:
+    return {'item_id': 1}
+
+
+@pytest.fixture
+def mock_request():
+    mock_request_patch = mock.patch('doctor.flask.request')
+    yield mock_request_patch.start()
+    mock_request_patch.stop()
+
+
+@pytest.fixture
+def mock_get_logic():
+    mock_logic = mock.Mock(spec=get_item, return_value={'item_id': 1})
+    mock_logic._doctor_signature = inspect.signature(get_item)
+    mock_logic._doctor_params = get_params_from_func(mock_logic)
+    return mock_logic
+
+
+def test_handle_http_with_json(mock_request, mock_get_logic):
+    mock_request.method = 'POST'
+    mock_request.content_type = 'application/json; charset=UTF8'
+    mock_request.mimetype = 'application/json'
+    mock_request.json = {'item_id': 1, 'include_deleted': True}
+    mock_handler = mock.Mock()
+
+    actual = handle_http_v3(mock_handler, (), {}, mock_get_logic)
+    assert actual == ({'item_id': 1}, 201)
+
+    expected_call = mock.call(item_id=1, include_deleted=True)
+    assert expected_call == mock_get_logic.call_args
+
+
+def test_handle_http_non_json(mock_request, mock_get_logic):
+    mock_request.method = 'GET'
+    mock_request.content_type = 'application/x-www-form-urlencoded'
+    mock_request.values = {'item_id': 3}
+    mock_handler = mock.Mock()
+
+    actual = handle_http_v3(mock_handler, (), {}, mock_get_logic)
+    assert actual == ({'item_id': 1}, 200)
+
+    expected_call = mock.call(item_id=3)
+    assert expected_call == mock_get_logic.call_args
+
+
+def test_handle_http_unsupported_http_method_with_body(
+        mock_request, mock_get_logic):
+    mock_request.method = 'GET'
+    mock_request.content_type = 'application/json; charset=UTF8'
+    mock_request.mimetype = 'application/json'
+    mock_request.values = {'item_id': 3}
+    mock_handler = mock.Mock()
+
+    actual = handle_http_v3(mock_handler, (), {}, mock_get_logic)
+    assert actual == ({'item_id': 1}, 200)
+
+    expected_call = mock.call(item_id=3)
+    assert expected_call == mock_get_logic.call_args
+
+
+def test_handle_http_missing_required_arg(mock_request, mock_get_logic):
+    mock_request.method = 'GET'
+    mock_request.content_type = 'application/x-www-form-urlencoded'
+    mock_request.values = {}
+    mock_handler = mock.Mock()
+
+    with pytest.raises(HTTP400Exception, match='item_id is required'):
+        handle_http_v3(mock_handler, (), {}, mock_get_logic)
+
+
+def test_handle_http_invalid_param(mock_request, mock_get_logic):
+    mock_request.method = 'GET'
+    mock_request.content_type = 'application/x-www-form-urlencoded'
+    mock_request.values = {'item_id': 'string'}
+    mock_handler = mock.Mock()
+
+    with pytest.raises(HTTP400Exception, match='Must be a valid number.'):
+        handle_http_v3(mock_handler, (), {}, mock_get_logic)
+
+
+def test_handle_http_response_instance_return_value(
+        mock_request, mock_get_logic):
+    mock_request.method = 'GET'
+    mock_request.content_type = 'application/json; charset=UTF8'
+    mock_request.mimetype = 'application/json'
+    mock_request.values = {'item_id': 3}
+    mock_get_logic.return_value = Response({'item_id': 3}, {'X-Header': 'Foo'})
+    mock_handler = mock.Mock()
+
+    actual = handle_http_v3(mock_handler, (), {}, mock_get_logic)
+    assert actual == ({'item_id': 3}, 200, {'X-Header': 'Foo'})

--- a/test/test_router_v3.py
+++ b/test/test_router_v3.py
@@ -1,0 +1,134 @@
+import inspect
+
+from doctor.router_v3 import (
+    create_routes, delete, get, get_params_from_func, post, put, Params)
+from doctor.types import array, boolean, integer, string
+
+
+Name = string('name', min_length=1)
+Age = integer('age', minimum=1, maximum=120)
+IsAlive = boolean('Is alive?')
+FooId = integer('foo id')
+Foo = string('foo')
+Foos = array('foos', items=Foo)
+
+
+def delete_foo(foo_id: FooId):
+    pass
+
+
+def get_foo(name: Name, age: Age, is_alive: IsAlive=True) -> Foo:
+    return ''
+
+
+def get_foos(is_alive: IsAlive=True) -> Foos:
+    return ''
+
+
+def create_foo(name: Name) -> Foo:
+    return ''
+
+
+def update_foo(foo_id: FooId, name: Name, is_alive: IsAlive=True) -> Foo:
+    return ''
+
+
+def no_params() -> Foo:
+    return ''
+
+
+class TestRouterV3(object):
+
+    def test_delete(self):
+        expected = {
+            'http_method': 'delete',
+            'logic': get_foo,
+        }
+        assert expected == delete(get_foo)
+
+    def test_get(self):
+        expected = {
+            'http_method': 'get',
+            'logic': get_foo,
+        }
+        assert expected == get(get_foo)
+
+    def test_post(self):
+        expected = {
+            'http_method': 'post',
+            'logic': get_foo,
+        }
+        assert expected == post(get_foo)
+
+    def test_put(self):
+        expected = {
+            'http_method': 'put',
+            'logic': get_foo,
+        }
+        assert expected == put(get_foo)
+
+    def test_get_params_from_func(self):
+        get_foo._doctor_signature = inspect.signature(get_foo)
+        expected = Params(
+            all=['name', 'age', 'is_alive'],
+            optional=['is_alive'],
+            required=['name', 'age'])
+        assert expected == get_params_from_func(get_foo)
+
+    def test_get_params_from_func_no_params(self):
+        no_params._doctor_signature = inspect.signature(no_params)
+        expected = Params([], [], [])
+        assert expected == get_params_from_func(no_params)
+
+    def test_create_routes(self):
+        routes = (
+            ('^/foo/?$', (
+                get(get_foos),
+                post(create_foo))),
+            ('^/foo/<int:foo_id>/?$', (
+                delete(delete_foo),
+                get(get_foo),
+                put(update_foo))),
+        )
+        actual = create_routes(routes)
+
+        # 2 routes created
+        assert 2 == len(actual)
+
+        # verify the first route
+        route, handler = actual[0]
+        assert r'^/foo/?$' == route
+
+        # verify each http method was added
+        assert hasattr(handler, 'get')
+        assert hasattr(handler, 'post')
+
+        # verify params for get
+        params = handler.get._doctor_params
+        expected = Params(
+            all=['is_alive'], required=[], optional=['is_alive'])
+        assert expected == params
+
+        # verify signature
+        sig = handler.get._doctor_signature
+        expected = inspect.signature(get_foos)
+        assert expected == sig
+
+        # verify params for post
+        params = handler.post._doctor_params
+        expected = Params(
+            all=['name'], required=['name'], optional=[])
+        assert expected == params
+
+        # verify signature
+        sig = handler.post._doctor_signature
+        expected = inspect.signature(create_foo)
+        assert expected == sig
+
+        # verify the second route
+        route, handler = actual[1]
+        assert '^/foo/<int:foo_id>/?$' == route
+        # verify each http method was added
+        assert hasattr(handler, 'get')
+        assert hasattr(handler, 'delete')
+        assert hasattr(handler, 'put')


### PR DESCRIPTION
This adds logic for creating routes that get validated using the doctor python types.  I decided to break this up into some smaller tasks so the PR isn't too large.

I'll address the TODOS in the comments in a follow up PR.  The current version has the base, basic functionality.  The example app was also updated and can be run locally.