### PR TITLE
Feature/issue 50 Add util to add request parameter annotations to a logic function.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Usage
    parsing
    errors
    types
+   utils
 
 .. include:: ../CHANGELOG.rst
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,0 +1,11 @@
+Utils
+=====
+
+
+Module Documentation
+--------------------
+.. automodule:: doctor.utils
+    :members:
+    :private-members:
+    :show-inheritance:
+

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -126,7 +126,10 @@ def handle_http_v3(handler: flask_restful.Resource, args: Tuple, kwargs: Dict,
             annotation = sig.parameters[name].annotation
             params[name] = annotation(value)
 
-        response = logic(*args, **params)
+        # Only pass request parameters defined by the logic signature.
+        logic_params = {k: v for k, v in params.items()
+                        if k in logic._doctor_params.logic}
+        response = logic(*args, **logic_params)
 
         # response validation
         if sig.return_annotation != sig.empty:

--- a/doctor/routing.py
+++ b/doctor/routing.py
@@ -14,8 +14,7 @@ class HTTPMethod(object):
     When instantiated the logic attribute will have 3 attributes added to it:
         - `_doctor_allowed_exceptions` - A list of excpetions that are allowed
           to be re-reaised if encountered during a request.
-        - `_doctor_params` - A `Params` instance containg all params,
-          required params, optional params and logic function params.
+        - `_doctor_params` - A :class:`~doctor.utils.Params` instance.
         - `_doctor_signature` - The parsed function Signature.
 
     :param method: The HTTP method.  One of: (delete, get, post, put).
@@ -26,12 +25,17 @@ class HTTPMethod(object):
     def __init__(self, method: str, logic: Callable,
                  allowed_exceptions: List=None):
         self.method = method
-        # Add doctor attributes to logic
+
+        # Add doctor attributes to logic.  We do a check to ensure some
+        # attributes aren't already set in the event that
+        # doctor.utils.add_param_annotations was used to add additional
+        # request parameters to the logic function that aren't part of it's
+        # signature.
         if not hasattr(logic, '_doctor_signature'):
             logic._doctor_signature = inspect.signature(logic)
-        logic._doctor_allowed_exceptions = allowed_exceptions
         if not hasattr(logic, '_doctor_params'):
             logic._doctor_params = get_params_from_func(logic)
+        logic._doctor_allowed_exceptions = allowed_exceptions
         self.logic = logic
 
 

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -38,7 +38,6 @@ import isodate
 import rfc3987
 
 from doctor.errors import SchemaError, SchemaValidationError, TypeSystemError
-from doctor.flask import FlaskResourceSchema
 
 
 class SuperType(object):
@@ -397,6 +396,8 @@ class JsonSchema(SuperType):
     definition_key = None  # type: str
 
     def __init__(self, data: typing.Any):
+        # Importing here to avoid circular dependencies
+        from doctor.flask import FlaskResourceSchema
         self.schema = FlaskResourceSchema.from_file(self.schema_file)
         request_schema = None
 

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -2,6 +2,9 @@ import inspect
 import os
 import re
 import sys
+from copy import copy
+from inspect import Parameter, Signature
+from typing import Callable, List
 
 import six
 try:
@@ -9,11 +12,115 @@ try:
 except ImportError:
     prepare_docstring = None
 
+from doctor.types import SuperType
 
 #: Used to identify the end of the description block, and the beginning of the
 #: parameters. This assumes that the parameters and such will always occur at
 #: the end of the docstring.
 DESCRIPTION_END_RE = re.compile(':(arg|param|returns|throws)', re.I)
+
+
+class RequestParamAnnotation(object):
+    """Represents a new request parameter annotation.
+
+    :param name: The name of the parameter.
+    :param annotation: The annotation type of the parameter.
+    :param required: Indicates if the parameter is required or not.
+    """
+    def __init__(self, name: str, annotation, required: bool=False):
+        self.annotation = annotation
+        self.name = name
+        self.required = required
+
+
+class Params(object):
+    """Represents parameters for a reuqest.
+
+    :param all: A list of all paramter names for a request.
+    :param required: A list of all required parameter names for a request.
+    :param optional: A list of all optional parameter names for a request.
+    :param logic: A list of all parameter names for the logic function.
+    """
+    def __init__(self, all: List[str], required: List[str],
+                 optional: List[str], logic: List[str]):
+        self.all = all
+        self.optional = optional
+        self.required = required
+        self.logic = logic
+
+    def __repr__(self):
+        return str({
+            'all': self.all,
+            'logic': self.logic,
+            'optional': self.optional,
+            'required': self.required
+        })
+
+    def __eq__(self, other):
+        for attr in ('all', 'logic', 'optional', 'required'):
+            if getattr(self, attr) != getattr(other, attr):
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+def get_params_from_func(func: Callable, signature: Signature=None) -> Params:
+    """Gets all parameters from a function signature.
+
+    :param func: The function to inspect.
+    :returns: A named tuple containing information about all, optional,
+        required and logic function parameters.
+    """
+    if not signature:
+        signature = func._doctor_signature
+    # Required is a positional argument with no defualt value and it's
+    # annotation must sub class SuperType.  This is so we don't try to
+    # require parameters passed to a logic function by a decorator that are
+    # not part of a request.
+    required = [key for key, p in signature.parameters.items()
+                if p.default == p.empty and issubclass(p.annotation, SuperType)]
+    optional = [key for key, p in signature.parameters.items()
+                if p.default != p.empty]
+    all_params = [key for key in signature.parameters.keys()]
+    logic_params = copy(all_params)
+    return Params(all_params, required, optional, logic_params)
+
+
+def add_param_annotations(
+        logic: Callable, params: List[RequestParamAnnotation]) -> Callable:
+    """Adds parameter annotations to a logic function.
+
+    This adds additional required and/or optional parameters to the logic
+    function that are not part of it's signature.  It's intended to be used
+    by decorators decorating logic functions or middleware.
+
+    :param logic: The logic function to add the parameter annotations to.
+    :param params: The list of RequestParamAnnotations to add to the logic func.
+    :returns: The logic func with updated parameter annotations.
+    """
+    sig = inspect.signature(logic)
+    doctor_params = get_params_from_func(logic, sig)
+
+    new_params = []
+    for param in params:
+        doctor_params.all.append(param.name)
+        default = None
+        if param.required:
+            default = Parameter.empty
+            doctor_params.required.append(param.name)
+        else:
+            doctor_params.optional.append(param.name)
+        new_params.append(
+                Parameter(param.name, Parameter.KEYWORD_ONLY, default=default,
+                          annotation=param.annotation))
+
+    prev_parameters = [p for _, p in sig.parameters.items()]
+    new_sig = sig.replace(parameters=prev_parameters + new_params)
+    logic._doctor_signature = new_sig
+    logic._doctor_params = doctor_params
+    return logic
 
 
 def nested_set(data, keys, value):

--- a/test/test_flask_v3.py
+++ b/test/test_flask_v3.py
@@ -8,17 +8,10 @@ import pytest
 from doctor.flask import (
     handle_http_v3, HTTP400Exception, should_raise_response_validation_errors)
 from doctor.response import Response
-from doctor.types import integer, boolean, Object, new_type, string
 from doctor.utils import (
     add_param_annotations, get_params_from_func, Params, RequestParamAnnotation)
 
-
-Auth = string('auth token')
-ItemId = integer('item id', minimum=1)
-Item = new_type(Object, 'item', properties={'item_id': ItemId},
-                additional_properties=False, required=['item_id'])
-IncludeDeleted = boolean('indicates if deleted items should be included.')
-IsDeleted = boolean('Indicates if the item should be marked as deleted')
+from .types import Auth, Item, ItemId, IncludeDeleted
 
 
 def check_auth(func):
@@ -107,8 +100,8 @@ def test_handle_http_decorator_adds_param_annotations(
         mock_request, mock_get_logic):
     """
     This test verifies if a decorator uses doctor.utils.add_param_annotations
-    to the logic function that we fail to validate if the added params are
-    missing or invalid.
+    to add params to the logic function that we fail to validate if the added
+    params are missing or invalid.
     """
     mock_request.method = 'GET'
     mock_request.content_type = 'application/x-www-form-urlencoded'

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -4,9 +4,9 @@ from functools import wraps
 from flask_restful import Resource
 
 from doctor.routing import (
-    create_routes, delete, get, get_params_from_func, post, put, HTTPMethod,
-    Params, Route)
+    create_routes, delete, get, post, put, HTTPMethod, Route)
 from doctor.types import array, boolean, integer, string
+from doctor.utils import get_params_from_func, Params
 
 
 Name = string('name', min_length=1)
@@ -53,7 +53,7 @@ def decorated_func(extra: str, name: Name, is_alive: IsAlive=True) -> Foo:
     return ''
 
 
-class TestRouterV3(object):
+class TestRouting(object):
 
     def test_httpmethod(self):
         m = HTTPMethod('get', get_foo, allowed_exceptions=[ValueError])
@@ -63,7 +63,8 @@ class TestRouterV3(object):
         expected = Params(
             all=['name', 'age', 'is_alive'],
             optional=['is_alive'],
-            required=['name', 'age'])
+            required=['name', 'age'],
+            logic=['name', 'age', 'is_alive'])
         assert expected == m.logic._doctor_params
         assert [ValueError] == m.logic._doctor_allowed_exceptions
 
@@ -96,12 +97,13 @@ class TestRouterV3(object):
         expected = Params(
             all=['name', 'age', 'is_alive'],
             optional=['is_alive'],
-            required=['name', 'age'])
+            required=['name', 'age'],
+            logic=['name', 'age', 'is_alive'])
         assert expected == get_params_from_func(get_foo)
 
     def test_get_params_from_func_no_params(self):
         no_params._doctor_signature = inspect.signature(no_params)
-        expected = Params([], [], [])
+        expected = Params([], [], [], [])
         assert expected == get_params_from_func(no_params)
 
     def test_get_params_from_func_decorated_func(self):
@@ -114,7 +116,8 @@ class TestRouterV3(object):
         expected = Params(
             all=['extra', 'name', 'is_alive'],
             required=['name'],
-            optional=['is_alive'])
+            optional=['is_alive'],
+            logic=['extra', 'name', 'is_alive'])
         assert expected == get_params_from_func(decorated_func)
 
     def test_create_routes(self):
@@ -152,7 +155,8 @@ class TestRouterV3(object):
         # verify params for get
         params = handler.get._doctor_params
         expected = Params(
-            all=['is_alive'], required=[], optional=['is_alive'])
+            all=['is_alive'], required=[], optional=['is_alive'],
+            logic=['is_alive'])
         assert expected == params
 
         # verify signature
@@ -163,7 +167,7 @@ class TestRouterV3(object):
         # verify params for post
         params = handler.post._doctor_params
         expected = Params(
-            all=['name'], required=['name'], optional=[])
+            all=['name'], required=['name'], optional=[], logic=['name'])
         assert expected == params
 
         # verify signature

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -1,20 +1,12 @@
 import inspect
-from functools import wraps
 
 from flask_restful import Resource
 
 from doctor.routing import (
     create_routes, delete, get, post, put, HTTPMethod, Route)
-from doctor.types import array, boolean, integer, string
-from doctor.utils import get_params_from_func, Params
+from doctor.utils import Params
 
-
-Name = string('name', min_length=1)
-Age = integer('age', minimum=1, maximum=120)
-IsAlive = boolean('Is alive?')
-FooId = integer('foo id')
-Foo = string('foo')
-Foos = array('foos', items=Foo)
+from .types import Age, Foo, FooId, Foos, IsAlive, Name
 
 
 def delete_foo(foo_id: FooId):
@@ -34,22 +26,6 @@ def create_foo(name: Name) -> Foo:
 
 
 def update_foo(foo_id: FooId, name: Name, is_alive: IsAlive=True) -> Foo:
-    return ''
-
-
-def no_params() -> Foo:
-    return ''
-
-
-def pass_pos_param(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        return func('extra!', *args, **kwargs)
-    return wrapper
-
-
-@pass_pos_param
-def decorated_func(extra: str, name: Name, is_alive: IsAlive=True) -> Foo:
     return ''
 
 
@@ -91,34 +67,6 @@ class TestRouting(object):
         actual = put(get_foo)
         assert actual.method == expected.method
         assert actual.logic == expected.logic
-
-    def test_get_params_from_func(self):
-        get_foo._doctor_signature = inspect.signature(get_foo)
-        expected = Params(
-            all=['name', 'age', 'is_alive'],
-            optional=['is_alive'],
-            required=['name', 'age'],
-            logic=['name', 'age', 'is_alive'])
-        assert expected == get_params_from_func(get_foo)
-
-    def test_get_params_from_func_no_params(self):
-        no_params._doctor_signature = inspect.signature(no_params)
-        expected = Params([], [], [], [])
-        assert expected == get_params_from_func(no_params)
-
-    def test_get_params_from_func_decorated_func(self):
-        """
-        Verifies that we don't include the `extra` param as required since
-        it's not a sublcass of `SuperType` and is passed to the function
-        by a decorator.
-        """
-        decorated_func._doctor_signature = inspect.signature(decorated_func)
-        expected = Params(
-            all=['extra', 'name', 'is_alive'],
-            required=['name'],
-            optional=['is_alive'],
-            logic=['extra', 'name', 'is_alive'])
-        assert expected == get_params_from_func(decorated_func)
 
     def test_create_routes(self):
         class MyHandler(Resource):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,15 +7,33 @@ import six
 
 from .base import TestCase
 
+from doctor.routing import get_params_from_func
 from doctor.utils import (
-    exec_params, get_description_lines, get_module_attr, nested_set,
-    undecorate_func)
+    add_param_annotations, exec_params, get_description_lines, get_module_attr,
+    nested_set, undecorate_func, RequestParamAnnotation)
 
 
 if six.PY2:
     getargspec_func = inspect.getargspec
 else:
     getargspec_func = inspect.getfullargspec
+
+
+def test_inject_parameters_into_logic_function():
+    def logic(foo: str, bar: bool=None) -> str:
+        return f'{foo} - {bar}'
+
+    logic._doctor_signature = inspect.signature(logic)
+    logic._doctor_params = get_params_from_func(logic)
+    print(logic._doctor_signature)
+    print(logic._doctor_params)
+    new_params = [
+        RequestParamAnnotation('test', int, True),
+        RequestParamAnnotation('l', str)
+    ]
+    actual = add_param_annotations(logic, new_params)
+    print(actual._doctor_signature)
+    print(actual._doctor_params)
 
 
 def does_nothing(func):

--- a/test/types.py
+++ b/test/types.py
@@ -1,12 +1,18 @@
 """
 This module contains custom types used by tests.
 """
-from doctor.types import array, boolean, integer, string
+from doctor.types import array, boolean, integer, new_type, string, Object
 
 
-Name = string('name', min_length=1)
 Age = integer('age', minimum=1, maximum=120)
-IsAlive = boolean('Is alive?')
-FooId = integer('foo id')
+Auth = string('auth token')
 Foo = string('foo')
+FooId = integer('foo id')
 Foos = array('foos', items=Foo)
+IsAlive = boolean('Is alive?')
+ItemId = integer('item id', minimum=1)
+Item = new_type(Object, 'item', properties={'item_id': ItemId},
+                additional_properties=False, required=['item_id'])
+IncludeDeleted = boolean('indicates if deleted items should be included.')
+IsDeleted = boolean('Indicates if the item should be marked as deleted')
+Name = string('name', min_length=1)

--- a/test/types.py
+++ b/test/types.py
@@ -1,0 +1,12 @@
+"""
+This module contains custom types used by tests.
+"""
+from doctor.types import array, boolean, integer, string
+
+
+Name = string('name', min_length=1)
+Age = integer('age', minimum=1, maximum=120)
+IsAlive = boolean('Is alive?')
+FooId = integer('foo id')
+Foo = string('foo')
+Foos = array('foos', items=Foo)


### PR DESCRIPTION
This adds a util function `add_param_annotations` that can add additional required/optional request parameters that are not part of the function signature.  These parameters will get validated against their type and raise a 400 if they are missing.  This is intended to be used by code using doctor that requires certain parameters but they are not passed to the logic function.

An example would be a decorator that checks for a valid auth token.  Instead of having to add the parameter to every function that requires it and then not use it you would instead update the decorator to specify that it's required.  For example:

```python
from functools import wraps
from doctor.types import string
from doctor.utils import add_param_annotations, RequestParamAnnotation

Auth = string('A valid auth token', min_length=20)

def check_auth(func):
    @wraps(func)
    def wrapper(*args, **kwargs):
        # Does validation against the auth request parameter...
        return func(*args, **kwargs)
    params = [
        RequestParamAnnotation('auth', Auth, required=True),
    ]
    _wrapper = add_param_annotations(wrapper, params)
    return _wrapper

@check_auth
def get_item() -> Item:
    # ...
```