### PR TITLE
Add common-sense default example values for types.

### DIFF
--- a/doctor/docs/base.py
+++ b/doctor/docs/base.py
@@ -719,7 +719,7 @@ class BaseHarness(object):
         if defined_values and not defined_values['update']:
             return defined_values['values']
         values = {
-            k: v.annotation.example
+            k: v.annotation.get_example()
             for k, v in annotation.annotated_parameters.items()
         }
         if defined_values:

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -435,7 +435,7 @@ class Array(SuperType, list):
 
     @classmethod
     def get_example(cls) -> list:
-        """Returns an example value for the JsonSchema type.
+        """Returns an example value for the Array type.
 
         If an example isn't a defined attribute on the class we return
         a list of 1 item containing the example value of the `items` attribute.

--- a/test/schema/annotation.yaml
+++ b/test/schema/annotation.yaml
@@ -4,6 +4,7 @@ definitions:
   annotation_id:
     description: Auto-increment ID.
     type: integer
+    example: 1
   auth:
     $ref: 'common.yaml#/definitions/auth'
   bad_ref:
@@ -15,15 +16,19 @@ definitions:
   name:
     description: Human readable name.
     type: string
+    example: Annotation
   url:
     description: The URL to the detail page for the annotation.
     type: string
     format: uri
+    example: https://upsight.com
   urls:
     description: An array of url's.
     type: array
     items:
       '$ref': '#/definitions/url'
+    example:
+      - https://upsight.com
   annotation:
     $ref: '#'
   annotations:
@@ -59,6 +64,12 @@ invalid_ref_chain_1:
 invalid_ref_chain_2:
   $ref: '#/invalid_ref_chain_3'
 additionalProperties: no
+example:
+  annotation_id: 1
+  auth: token
+  more_id: 1
+  name: Annotation
+  url: https://upsight.com
 allOf:
   - $ref: "common.yaml"
   - $ref: "subdir/more.yaml"

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -120,7 +120,7 @@ class TestSchemaRefResolver(TestCase):
         uri, value = self.resolver.resolve('#/test_ref')
         self.assertEqual(uri, self.base_uri + '#/definitions/annotation_id')
         self.assertEqual(value, {'description': 'Auto-increment ID.',
-                                 'type': 'integer'})
+                                 'type': 'integer', 'example': 1})
 
     def test_resolve_external(self):
         """Should be able to resolve references to other files."""

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -114,6 +114,14 @@ class TestString(object):
         with pytest.raises(TypeSystemError, match=expected_msg):
             S('foo')
 
+    def test_get_example(self):
+        S = string('A string.', example='Foo')
+        assert 'Foo' == S.get_example()
+
+        # Default example
+        S = string('A string.')
+        assert 'string' == S.get_example()
+
 
 class TestNumericType(object):
 
@@ -169,6 +177,28 @@ class TestNumericType(object):
             N(5)
 
 
+class TestNumber(object):
+
+    def test_get_example(self):
+        N = number('A float', example=1.12)
+        assert 1.12 == N.get_example()
+
+        # Default example
+        N = number('Pi')
+        assert 3.14 == N.get_example()
+
+
+class TestInteger(object):
+
+    def test_get_example(self):
+        I = integer('An int', example=1022)  # noqa
+        assert 1022 == I.get_example()
+
+        # Default example
+        I = integer('An ID')  # noqa
+        assert 1 == I.get_example()
+
+
 class TestBoolean(object):
 
     def test_boolean_type(self):
@@ -193,6 +223,14 @@ class TestBoolean(object):
         with pytest.raises(TypeSystemError, match='Must be a valid boolean.'):
             B('dog')
 
+    def test_get_example(self):
+        B = boolean('A bool', example=False)
+        assert B.get_example() is False
+
+        # Default example
+        B = boolean('A bool')
+        assert B.get_example() is True
+
 
 class TestEnum(object):
 
@@ -204,6 +242,14 @@ class TestEnum(object):
         # not in choices
         with pytest.raises(TypeSystemError, match='Must be a valid choice'):
             E('dog')
+
+    def test_get_example(self):
+        E = enum('choices', enum=['foo', 'bar'], example='bar')
+        assert 'bar' == E.get_example()
+
+        # Default example (1st item in enum)
+        E = enum('choices', enum=['foo', 'bar'])
+        assert 'foo' == E.get_example()
 
 
 class FooObject(Object):
@@ -264,6 +310,13 @@ class TestObject(object):
                            match="{'bar': 'This field is required.'}"):
             RequiredPropsObject(expected)
 
+    def test_get_example(self):
+        # default example is generated from example values of it's properties.
+        assert {'foo': 'string', 'bar': 1} == RequiredPropsObject.get_example()
+        # with a defined example
+        setattr(RequiredPropsObject, 'example', {'foo': 'foo', 'bar': 33})
+        assert {'foo': 'foo', 'bar': 33} == RequiredPropsObject.get_example()
+
 
 class TestArray(object):
 
@@ -323,6 +376,16 @@ class TestArray(object):
         A = array('unique', unique_items=True)
         with pytest.raises(TypeSystemError, match='This item is not unique.'):
             A([1, 1, 1, 2])
+
+    def test_get_example(self):
+        A = array('No example of items')
+        assert [1] == A.get_example()
+
+        A = array('Defined example', example=['a', 'b'])
+        assert ['a', 'b'] == A.get_example()
+
+        A = array('No example, defined items', items=string('letter'))
+        assert ['string'] == A.get_example()
 
 
 class TestJsonSchema(object):


### PR DESCRIPTION
Current an `example` attribute is "required" for all types a user defines.  A lot of the time though this is always the same value.  For example an integer will likely use the value `1`, a boolean `True`, etc.  So by defining a default value for all types would cut down on what the user needs to define, but they still the ability to override it.

Also the `Array` and `Object` types have underlying types which already have examples.  So we should be able to generate an example from them.  For an Array type it has a required `items` attribute and the type assigned would have a user defined example or a default one.  Similarly Object` types could just generate an example from the property types.

A quick example:

```python
from doctor.types import array, boolean, integer, Object

Email = string('An email address.', format='email', example='user@domain.com')
IsActive = boolean('Indicates if the account is active or not.', example=True)
Password = string('A password', min_length=6, example='password')
UserId = integer('The ID of the user.', example=1)

Emails = array('An array of email addresses.' items=Email)
# The example from the above would use the example from Email and put it in a list:
# ['user@domain.com']

class AuthorizedUser(Object):
    additional_properties = False
    properties = {
        'email': Email,
        'id': UserId,
        'is_active': IsActive,
    }
# The example from above would use examples from the property types which would be:
{
    'email': 'user@domain.com',
    'id': 1,
    'is_active': True
}
