### PR TITLE
Feature/remove f strings

### DIFF
--- a/doctor/docs/base.py
+++ b/doctor/docs/base.py
@@ -281,6 +281,8 @@ def prefix_lines(lines, prefix):
     :param str prefix: Prefix to add to the lines. Usually an indent.
     :returns: list
     """
+    if isinstance(lines, bytes):
+        lines = lines.decode('utf-8')
     if isinstance(lines, str):
         lines = lines.splitlines()
     return [prefix + line for line in lines]

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -114,7 +114,7 @@ def handle_http(handler: flask_restful.Resource, args: Tuple, kwargs: Dict,
         # Validate and coerce parameters to the appropriate types.
         for required in logic._doctor_params.required:
             if required not in params:
-                raise InvalidValueError(f'{required} is required.')
+                raise InvalidValueError('{} is required.'.format(required))
         sig = logic._doctor_signature
         for name, value in params.items():
             annotation = sig.parameters[name].annotation

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -344,7 +344,8 @@ class Object(SuperType, dict):
             properties = list(self.properties.keys())
             for key in value.keys():
                 if key not in properties:
-                    detail = f'{key} not in {properties}'
+                    detail = '{key} not in {properties}'.format(
+                        key=key, properties=properties)
                     exc = TypeSystemError(detail, cls=self.__class__,
                                           code='additional_properties')
                     errors[key] = exc.detail
@@ -474,16 +475,16 @@ class JsonSchema(SuperType):
                 definition = request_schema['definitions'][self.definition_key]
             except KeyError:
                 raise TypeSystemError(
-                    f'Definition `{self.definition_key}` is not defined in the '
-                    'schema.', cls=self.__class__)
+                    'Definition `{}` is not defined in the schema.'.format(
+                        self.definition_key), cls=self.__class__)
             if '$ref' in request_schema['definitions'][self.definition_key]:
                 try:
                     self.description = self.schema.resolve(
                         definition['$ref'])['description']
                 except KeyError:
                     raise TypeSystemError(
-                        f'Definition `{self.definition_key}` is missing a '
-                        f'description.', cls=self.__class__)
+                        'Definition `{}` is missing a description.'.format(
+                            self.definition_key), cls=self.__class__)
                 except SchemaError as e:
                     raise TypeSystemError(str(e), cls=self.__class__)
                 try:
@@ -491,8 +492,8 @@ class JsonSchema(SuperType):
                         definition['$ref'])['example']
                 except KeyError:
                     raise TypeSystemError(
-                        f'Definition `{self.definition_key}` is missing an '
-                        f'example.', cls=self.__class__)
+                        'Definition `{}` is missing an example.'.format(
+                            self.definition_key), cls=self.__class__)
                 except SchemaError as e:
                     raise TypeSystemError(str(e), cls=self.__class__)
             else:
@@ -500,14 +501,14 @@ class JsonSchema(SuperType):
                     self.description = definition['description']
                 except KeyError:
                     raise TypeSystemError(
-                        f'Definition `{self.definition_key}` is missing a '
-                        f'description.', cls=self.__class__)
+                        'Definition `{}` is missing a description.'.format(
+                            self.definition_key), cls=self.__class__)
                 try:
                     self.example = definition['example']
                 except KeyError:
                     raise TypeSystemError(
-                        f'Definition `{self.definition_key}` is missing an '
-                        f'example.', cls=self.__class__)
+                        'Definition `{}` is missing an example.'.format(
+                            self.definition_key), cls=self.__class__)
             data = {self.definition_key: data}
         else:
             try:

--- a/test/test_docs_base.py
+++ b/test/test_docs_base.py
@@ -15,6 +15,15 @@ from .utils import add_doctor_attrs
 
 class TestDocsBase(TestCase):
 
+    def test_prefix_lines_bytes(self):
+        """
+        This is a regression test where the response was a bytes instance.
+        """
+        lines = b'"Notes API v1.0.0"'
+        prefix = '   '
+        expected = ['   "Notes API v1.0.0"']
+        assert expected == base.prefix_lines(lines, prefix)
+
     def test_get_example_lines_json(self):
         """Tests an example when the response is valid JSON."""
         headers = {'GeoIp-Country-Code': 'US'}


### PR DESCRIPTION
readthedocs uses only up to python3.5 which does not support f strings (introduced in 3.6).  I've removed them so readthedocs can auto build our documentation.