### PR TITLE
Added code to generate more logical handler names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Next release (in development)
 -----------------------------
 
 v3.0.0-beta.3 (2018-02-28)
--------------------------
+--------------------------
 
 - Added default example values for all doctor types.
 - Documentation updates

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -201,7 +201,7 @@ def get_valid_class_name(s: str) -> str:
 
     Remove leading and trailing spaces; removes spaces and capitalizes each
     word; and remove anything that is not alphanumeric.  Returns a pep8
-    compaitble class name.
+    compatible class name.
 
     :param s: The string to convert.
     :returns: The updated string.

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -194,3 +194,18 @@ def get_description_lines(docstring):
     if lines and lines[-1] != '':
         lines.append('')
     return lines
+
+
+def get_valid_class_name(s: str) -> str:
+    """Return the given string converted so that it can be used for a class name
+
+    Remove leading and trailing spaces; removes spaces and capitalizes each
+    word; and remove anything that is not alphanumeric.  Returns a pep8
+    compaitble class name.
+
+    :param s: The string to convert.
+    :returns: The updated string.
+    """
+    s = str(s).strip()
+    s = ''.join([w.title() for w in re.split('\W+|_', s)])
+    return re.sub(r'[^\w|_]', '', s)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,8 +7,8 @@ import mock
 
 from doctor.routing import get_params_from_func
 from doctor.utils import (
-    add_param_annotations, get_description_lines, get_module_attr, Params,
-    RequestParamAnnotation)
+    add_param_annotations, get_description_lines, get_module_attr,
+    get_valid_class_name, Params, RequestParamAnnotation)
 
 from .base import TestCase
 from .types import Age, Auth, Foo, IsAlive, IsDeleted, Name
@@ -197,3 +197,16 @@ class TestUtils(TestCase):
             optional=['is_alive'],
             logic=['extra', 'name', 'is_alive'])
         assert expected == get_params_from_func(decorated_func)
+
+    def test_get_valid_class_name(self):
+        tests = (
+            # (input, expected)
+            ('Notes', 'Notes'),
+            ('Notes (v1)', 'NotesV1'),
+            ('Notes - "v1"', 'NotesV1'),
+            ('note_book.', 'NoteBook'),
+            ('notes', 'Notes'),
+            ('note-book_v1 .', 'NoteBookV1'),
+        )
+        for s, expected in tests:
+            assert expected == get_valid_class_name(s)


### PR DESCRIPTION
In the previous version if a handler name wasn't specified it would be a
generic Handler1 (where the number was incremented with each new
handler).  This sometimes made debugging things difficult, especially in
tests and debugging api docs generation when there were errors.