### PR TITLE
Coerce doctor types to their native types before passing to logic functions

### DIFF
--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -119,7 +119,7 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
         sig = logic._doctor_signature
         for name, value in params.items():
             annotation = sig.parameters[name].annotation
-            params[name] = annotation(value)
+            params[name] = annotation.native_type(annotation(value))
 
         # Only pass request parameters defined by the logic signature.
         logic_params = {k: v for k, v in params.items()

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -198,7 +198,7 @@ class _NumericType(SuperType):
             if failed:
                 raise TypeSystemError(cls=cls, code='multiple_of')
 
-        # Coerce value to the native str type.  We only do this if the value
+        # Coerce value to the native type.  We only do this if the value
         # is an instance of the class.
         if isinstance(value, cls):
             value = cls.native_type(value)

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -125,6 +125,11 @@ class String(SuperType, str):
             except ValueError as e:
                 raise TypeSystemError(str(e), cls=cls)
 
+        # Coerce value to the native str type.  We only do this if the value
+        # is an instance of the class.  It could be a datetime instance or
+        # a str already if `trim_whitespace` is True.
+        if isinstance(value, cls):
+            value = cls.native_type(value)
         return value
 
     @classmethod
@@ -193,6 +198,10 @@ class _NumericType(SuperType):
             if failed:
                 raise TypeSystemError(cls=cls, code='multiple_of')
 
+        # Coerce value to the native str type.  We only do this if the value
+        # is an instance of the class.
+        if isinstance(value, cls):
+            value = cls.native_type(value)
         return value
 
 
@@ -367,6 +376,7 @@ class Object(SuperType, dict):
 
 class Array(SuperType, list):
     """Represents a `list` type."""
+    native_type = list
     errors = {
         'type': 'Must be a list.',
         'min_items': 'Not enough items.',

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -66,7 +66,7 @@ def test_handle_http_object_array_types(mock_request):
     """
     This test verifies that we pass native types to the logic function rather
     than the doctor types that annotate the parameters of the logic function.
-    This is done to prevent downstream issues form happening by passing say
+    This is done to prevent downstream issues from happening by passing say
     an Integer instance instead of an int to pymysql.  pymysql doesn't know
     about this type and tries to escape it like a string which causes an
     AttributeError.

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -27,6 +27,10 @@ class TestSuperType(object):
 
 class TestString(object):
 
+    def test_type(self):
+        S = string('string')
+        assert type(S('string')) is str
+
     def test_trim_whitespace(self):
         S = string('a string', trim_whitespace=True)
         actual = S(' foo ')
@@ -179,6 +183,10 @@ class TestNumericType(object):
 
 class TestNumber(object):
 
+    def test_type(self):
+        N = number('float')
+        assert type(N(3.14)) is float
+
     def test_get_example(self):
         N = number('A float', example=1.12)
         assert 1.12 == N.get_example()
@@ -190,6 +198,10 @@ class TestNumber(object):
 
 class TestInteger(object):
 
+    def test_type(self):
+        I = integer('int')  # noqa
+        assert type(I(1)) is int
+
     def test_get_example(self):
         I = integer('An int', example=1022)  # noqa
         assert 1022 == I.get_example()
@@ -200,6 +212,10 @@ class TestInteger(object):
 
 
 class TestBoolean(object):
+
+    def test_type(self):
+        B = boolean('bool')
+        assert type(B('true')) is bool
 
     def test_boolean_type(self):
         B = boolean('A bool')
@@ -233,6 +249,10 @@ class TestBoolean(object):
 
 
 class TestEnum(object):
+
+    def test_type(self):
+        E = enum('choices', enum=['foo'])
+        assert type(E('foo')) is str
 
     def test_enum(self):
         E = enum('choices', enum=['foo', 'bar'])

--- a/test/utils.py
+++ b/test/utils.py
@@ -7,6 +7,7 @@ def add_doctor_attrs(func):
     """Adds required _doctor* attrs to a function so it can be used in tests."""
     sig = inspect.signature(func)
     params = get_params_from_func(func)
+    func._doctor_allowed_exceptions = None
     func._doctor_signature = sig
     func._doctor_params = params
     return func


### PR DESCRIPTION
This is done to prevent downstream issues (like #64 ) from happening by passing say
an Integer instance instead of an int to pymysql.  pymysql doesn't know
about this type and tries to escape it like a string which causes an
AttributeError.