### PR TITLE
Fixed a few bugs with `json_schema_type`.

### DIFF
--- a/doctor/types.py
+++ b/doctor/types.py
@@ -566,8 +566,12 @@ def get_value_from_schema(schema, definition: dict, key: str,
             value = {}
             for prop, definition in resolved_definition['properties'].items():
                 value[prop] = get_value_from_schema(
-                    schema, definition, key, 'root')
+                    schema, definition, key, definition_key)
             return value
+        # If the definition has a json reference, attempt to resolve it.
+        elif '$ref' in resolved_definition:
+            return get_value_from_schema(
+                schema, resolved_definition, key, definition_key)
         raise TypeSystemError(
             'Definition `{}` is missing a {}.'.format(
                 definition_key, key))

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -568,10 +568,6 @@ def get_value_from_schema(schema, definition: dict, key: str,
                 value[prop] = get_value_from_schema(
                     schema, definition, key, definition_key)
             return value
-        # If the definition has a json reference, attempt to resolve it.
-        elif '$ref' in resolved_definition:
-            return get_value_from_schema(
-                schema, resolved_definition, key, definition_key)
         raise TypeSystemError(
             'Definition `{}` is missing a {}.'.format(
                 definition_key, key))

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -41,6 +41,9 @@ from doctor.errors import SchemaError, SchemaValidationError, TypeSystemError
 from doctor.parsers import parse_value
 
 
+StrOrList = typing.Union[str, typing.List[str]]
+
+
 class MissingDescriptionError(ValueError):
     """An exception raised when a type is missing a description."""
     pass
@@ -531,6 +534,8 @@ def get_value_from_schema(schema, definition: dict, key: str,
                           definition_key: str, resolve: bool=False):
     """Gets a value from a schema and definition.
 
+    If the value has references it will recursively attempt to resolve them.
+
     :param ResourceSchema schema: The resource schema.
     :param dict definition: The definition dict from the schema.
     :param str key: The key to use to get the value from the schema.
@@ -541,18 +546,52 @@ def get_value_from_schema(schema, definition: dict, key: str,
     :raises TypeSystemError: If the key can't be found in the schema/definition
         or we can't resolve the definition.
     """
+    resolved_definition = definition.copy()
+    if resolve and '$ref' in resolved_definition:
+        try:
+            resolved_definition = schema.resolve(definition['$ref'])
+        except SchemaError as e:
+            raise TypeSystemError(str(e))
     try:
-        if resolve:
-            value = schema.resolve(definition['$ref'])[key]
-        else:
-            value = definition[key]
+        value = resolved_definition[key]
     except KeyError:
+        # If the key was missing and this is an array, try to resolve it
+        # from the items key.
+        if (resolved_definition['type'] == 'array' and
+                '$ref' in resolved_definition['items']):
+            return [
+                get_value_from_schema(schema, resolved_definition['items'], key,
+                                      definition_key, resolve=True)
+            ]
+        # If the key was missing and this is an object, resolve it from it's
+        # properties.
+        elif resolved_definition['type'] == 'object':
+            value = {}
+            for prop, definition in resolved_definition['properties'].items():
+                value[prop] = get_value_from_schema(
+                    schema, definition, key, 'root', resolve=True)
+            return value
         raise TypeSystemError(
             'Definition `{}` is missing a {}.'.format(
                 definition_key, key))
-    except SchemaError as e:
-        raise TypeSystemError(str(e))
     return value
+
+
+def get_types(json_type: StrOrList) -> typing.Tuple[str, str]:
+    """Returns the json and native python type based on the json_type input.
+
+    If json_type is a list of types it will return the first non 'null' value.
+
+    :param json_type: A json type or a list of json types.
+    :returns: A tuple containing the json type and native python type.
+    """
+    # If the type is a list, use the first non 'null' value as the type.
+    if isinstance(json_type, list):
+        for j_type in json_type:
+            if j_type != 'null':
+                json_type = j_type
+                break
+    return (json_type, JSON_TYPES_TO_NATIVE[json_type])
 
 
 def json_schema_type(schema_file: str, **kwargs) -> typing.Type:
@@ -586,29 +625,32 @@ def json_schema_type(schema_file: str, **kwargs) -> typing.Type:
                 schema, definition, 'description', definition_key, resolve=True)
             example = get_value_from_schema(
                 schema, definition, 'example', definition_key, resolve=True)
-            native_type = get_value_from_schema(
+            json_type = get_value_from_schema(
                 schema, definition, 'type', definition_key, resolve=True)
         else:
             description = get_value_from_schema(
                 schema, definition, 'description', definition_key)
             example = get_value_from_schema(
                 schema, definition, 'example', definition_key)
-            native_type = get_value_from_schema(
+            json_type = get_value_from_schema(
                 schema, definition, 'type', definition_key)
+        json_type, native_type = get_types(json_type)
         kwargs['description'] = description
         kwargs['example'] = example
-        kwargs['json_type'] = native_type
-        kwargs['native_type'] = JSON_TYPES_TO_NATIVE[native_type]
+        kwargs['json_type'] = json_type
+        kwargs['native_type'] = native_type
     else:
         try:
             kwargs['description'] = schema.schema['description']
         except KeyError:
             raise TypeSystemError('Schema is missing a description.')
         try:
-            kwargs['json_type'] = schema.schema['type']
-            kwargs['native_type'] = JSON_TYPES_TO_NATIVE[schema.schema['type']]
+            json_type = schema.schema['type']
         except KeyError:
             raise TypeSystemError('Schema is missing a type.')
+        json_type, native_type = get_types(json_type)
+        kwargs['json_type'] = json_type
+        kwargs['native_type'] = native_type
         try:
             kwargs['example'] = schema.schema['example']
         except KeyError:
@@ -616,8 +658,8 @@ def json_schema_type(schema_file: str, **kwargs) -> typing.Type:
             if schema.schema.get('properties'):
                 example = {}
                 for prop, definition in schema.schema['properties'].items():
-                    example[prop] = schema.resolve(
-                        definition['$ref'])['example']
+                    example[prop] = get_value_from_schema(
+                        schema, definition, 'example', 'root', resolve=True)
                 kwargs['example'] = example
             else:
                 raise TypeSystemError('Schema is missing an example.')

--- a/test/schema/annotation.yaml
+++ b/test/schema/annotation.yaml
@@ -15,7 +15,9 @@ definitions:
     $ref: 'subdir/more.yaml#/definitions/more_id'
   name:
     description: Human readable name.
-    type: string
+    type:
+      - 'null'
+      - string
     example: Annotation
   url:
     description: The URL to the detail page for the annotation.

--- a/test/schema/annotation_no_example.yaml
+++ b/test/schema/annotation_no_example.yaml
@@ -27,8 +27,6 @@ definitions:
     type: array
     items:
       '$ref': '#/definitions/url'
-    example:
-      - https://upsight.com
   annotation:
     $ref: '#'
   annotations:
@@ -49,6 +47,8 @@ properties:
     $ref: '#/definitions/name'
   url:
     $ref: '#/definitions/url'
+  urls:
+    $ref: '#/definitions/urls'
 test_ref:
   $ref: '#/another_test_ref'
 another_test_ref:

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -95,7 +95,7 @@ class TestSchema(TestCase):
         errors = context.exception.errors
         expected = {
             'annotation_id': expected_error,
-            'name': "1 is not of type 'string'",
+            'name': "1 is not of type 'null', 'string'",
         }
         self.assertEqual(expected, errors)
 


### PR DESCRIPTION
* If a definition's type is an array of types (e.g. ['null', 'integer']) it will blow up. 
* If an array definition doesn't define an example, an error will be raised, e.g. `doctor.errors.TypeSystemError: creatives missing example. 'example'`. In the previous version of doctor we would resolve the example based on the items. We should probably do the same here.
* Errors aren't handled when resolving example value properties when a definition_key isn't provided. If we call `get_value_from_schema` instead of manually resolving, it should display helpful error messages when it encounters exceptions.
* Simplified the logic in `json_schema_type`.
* Updated `get_value_from_schema` to recursively call itself if it encounters other refs.
