### PR TITLE
Bugfix/issue 77 Bugfixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Release History
 Next release (in development)
 -----------------------------
 
+v3.0.0-beta.6 (2018-03-08)
+--------------------------
+
+- Updated handle_http to parse query and form parameters from strings to
+  their expected type before we do validation on them.
+- Fixed issue where if multiple decorators were used on a logic function
+  and each one added param annotations the outer most decorator would
+  erase any param annotations added from the previous decorator.
+- Added a nullable attribute to all types to signify that None is a valid value
+  for the type, in addition to it's native type.
+
+
 v3.0.0-beta.5 (2018-03-05)
 --------------------------
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -39,6 +39,8 @@ Attributes
 
 * :attr:`~doctor.types.String.max_length` - The maximum length of the string.
 * :attr:`~doctor.types.String.min_length` - The minimum length of the string.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 * :attr:`~doctor.types.String.pattern` - A regex pattern the string should
   match anywhere whitin it.  Uses `re.search`.
 * :attr:`~doctor.types.String.trim_whitespace` - If `True` the string will be
@@ -81,6 +83,8 @@ Attributes
 * :attr:`~doctor.types._NumericType.minimum` - The minimum value allowed.
 * :attr:`~doctor.types._NumericType.multiple_of` - The value is required to be
   a multiple of this value.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 
 Example
 #######
@@ -120,6 +124,8 @@ Attributes
 * :attr:`~doctor.types._NumericType.minimum` - The minimum value allowed.
 * :attr:`~doctor.types._NumericType.multiple_of` - The value is required to be
   a multiple of this value.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 
 Example
 #######
@@ -157,6 +163,8 @@ Attributes
 * :attr:`~doctor.types.SuperType.example` - An example value to send to the
   endpoint when generating API documentation.  This is optional and a default
   example value will be generated for you.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 
 Example
 #######
@@ -183,6 +191,8 @@ Attributes
 * :attr:`~doctor.types.SuperType.example` - An example value to send to the
   endpoint when generating API documentation.  This is optional and a default
   example value will be generated for you.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 
 Example
 #######
@@ -213,6 +223,8 @@ Attributes
 * :attr:`~doctor.types.SuperType.example` - An example value to send to the
   endpoint when generating API documentation.  This is optional and a default
   example value will be generated for you.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 * :attr:`~doctor.types.Object.properties` - A dict containing a mapping of
   property name to expected type.
 * :attr:`~doctor.types.Object.required` - A list of required properties.
@@ -257,6 +269,8 @@ Attributes
   in the list.
 * :attr:`~doctor.types.Array.max_items` - The maximum number of items allowed
   in the list.
+* :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
+  is allowed to be None.
 * :attr:`~doctor.types.Array.unique_items` - If `True`, items in the array
   should be unique from one another.
 
@@ -400,13 +414,16 @@ Examples
                 if not value.lower().startswith('foo'):
                     raise TypeSystemError('Must start with foo', cls=cls)
 
-    MyFooString = new_type(FooString, 'My foo string')
+    MyFooString = new_type(FooString)
 
     # Create a new number type
     ProductRating = number('Product rating', maximum=10, minimum=1)
 
     # Create a new string type
     FirstName = string('First name', min_length=2, max_length=255)
+
+    # Create a new type based on FirstName, but is allowed to be None
+    NullableFirstName = new_type(FirstName, nullable=True)
 
 .. _types-module-documentation:
 

--- a/doctor/_version.py
+++ b/doctor/_version.py
@@ -1,1 +1,1 @@
-__version__ = '3.0.0-beta.5'
+__version__ = '3.0.0-beta.6'

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover
 from .constants import HTTP_METHODS_WITH_JSON_BODY
 from .errors import (ForbiddenError, ImmutableError, InvalidValueError,
                      NotFoundError, TypeSystemError, UnauthorizedError)
+from .parsers import parse_form_and_query_params
 from .response import Response
 from .routing import create_routes as doctor_create_routes
 from .routing import Route
@@ -115,7 +116,9 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
             request_params = request.json
         else:
             # Try to parse things from normal HTTP parameters
-            request_params = request.values
+            request_params = parse_form_and_query_params(
+                request.values, logic._doctor_signature.parameters)
+
         # Filter out any params not part of the logic signature.
         all_params = logic._doctor_params.all
         params = {k: v for k, v in request_params.items() if k in all_params}

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -130,11 +130,10 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
             if required not in params:
                 missing.append(required)
         if missing:
+            verb = 'are'
             if len(missing) == 1:
                 verb = 'is'
                 missing = missing[0]
-            else:
-                verb = 'are'
             error = '{} {} required.'.format(missing, verb)
             raise InvalidValueError(error)
 
@@ -143,6 +142,8 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
         sig = logic._doctor_signature
         for name, value in params.items():
             annotation = sig.parameters[name].annotation
+            if annotation.nullable and value is None:
+                continue
             try:
                 params[name] = annotation.native_type(annotation(value))
             except TypeSystemError as e:

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -117,9 +117,9 @@ def parse_value(value, allowed_types, name='value'):
         allowed_types = [allowed_types]
 
     # Note that the order of these type considerations is important. Because we
-    # an untyped value that may be one of any given number of types, we need
-    # a consistent order of evaluation cases when there is ambiguity between
-    # types.
+    # have an untyped value that may be one of any given number of types, we
+    # need a consistent order of evaluation in cases when there is ambiguity
+    # between types.
 
     if 'null' in allowed_types and value == '':
         return 'null', None

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -7,7 +7,7 @@ import logging
 
 import simplejson as json
 
-from doctor.errors import ParseError
+from doctor.errors import ParseError, TypeSystemError
 
 
 _bracket_strings = ('[', ord('['))
@@ -157,3 +157,43 @@ def parse_json(value):
         message = 'Error parsing JSON: %s' % e
         logging.debug(message, exc_info=e)
         raise ParseError(message)
+
+
+_native_type_to_json = {
+    list: 'array',
+    bool: 'boolean',
+    int: 'integer',
+    dict: 'object',
+    float: 'number',
+    str: 'string'
+}
+
+
+def parse_form_and_query_params(req_params, sig_params):
+    """Uses the parameter annotations to coerce string params.
+
+    This is used for HTTP requests, in which the form parameters are all
+    strings, but need to be converted to the appropriate types before
+    validating them.
+
+    :param dict req_params: The parameters specified in the request.
+    :param dict sig_params: The logic function's signature parameters.
+    :returns: a dict of params parsed from the input dict.
+    :raises TypeSystemError: If there are errors parsing values.
+    """
+    errors = {}
+    parsed_params = {}
+    for param, value in req_params.items():
+        if param not in sig_params:
+            continue
+        native_type = sig_params[param].annotation.native_type
+        json_type = _native_type_to_json[native_type]
+        try:
+            _, parsed_params[param] = parse_value(value, [json_type])
+        except ParseError as e:
+            errors[param] = str(e)
+
+    if errors:
+        raise TypeSystemError(errors, errors=errors)
+
+    return parsed_params

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -110,8 +110,14 @@ def add_param_annotations(
     :param params: The list of RequestParamAnnotations to add to the logic func.
     :returns: The logic func with updated parameter annotations.
     """
-    sig = inspect.signature(logic)
-    doctor_params = get_params_from_func(logic, sig)
+    # If we've already added param annotations to this function get the
+    # values from the logic, otherwise we need to inspect it.
+    if hasattr(logic, '_doctor_signature'):
+        sig = logic._doctor_signature
+        doctor_params = logic._doctor_params
+    else:
+        sig = inspect.signature(logic)
+        doctor_params = get_params_from_func(logic, sig)
 
     prev_parameters = {name: param for name, param in sig.parameters.items()}
     new_params = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 source = doctor
 
 [coverage:report]
+fail_under = 89
 show_missing = true
 
 [flake8]

--- a/test/flask_app.py
+++ b/test/flask_app.py
@@ -1,0 +1,129 @@
+# Note that this file contains some inline comments starting with # --, used to
+# generate documentation from this file. You're probably better served reading
+# the actual documentation (see Using in Flask in the docs).
+
+from flask import Flask
+from flask_restful import Api
+from doctor.errors import NotFoundError
+from doctor.flask import create_routes
+from doctor.routing import Route, get, post, put, delete
+# -- mark-types
+from doctor import types
+
+
+# doctor provides helper functions to easily define simple types.
+Body = types.string('Note body', example='body')
+Done = types.boolean('Marks if a note is done or not.', example=False)
+NoteId = types.integer('Note ID', example=1)
+Status = types.string('API status')
+NoteType = types.enum('The type of note', enum=['quick', 'detailed'],
+                      example='quick')
+NoteTypes = types.array('An array of note types', items=NoteType)
+
+
+# You can also inherit from type classes to create more complex types.
+class Note(types.Object):
+    description = 'A note object'
+    additional_properties = False
+    properties = {
+        'note_id': NoteId,
+        'body': Body,
+        'done': Done,
+    }
+    required = ['body', 'done', 'note_id']
+    example = {
+        'body': 'Example Body',
+        'done': True,
+        'note_id': 1,
+    }
+
+
+Notes = types.array('Array of notes', items=Note, example=[Note.example])
+
+# -- mark-logic
+
+note = {'note_id': 1, 'body': 'Example body', 'done': True}
+
+
+def example_array_and_object(note_types: NoteTypes, a_note: Note):
+    """Example signature that contains an object and an array."""
+    return {}
+
+
+# Note the type annotations on this function definition. This tells Doctor how
+# to parse and validate parameters for routes attached to this logic function.
+# The return type annotation will validate the response conforms to an
+# expected definition in development environments.  In non-development
+# environments a warning will be logged.
+def get_note(note_id: NoteId, note_type: NoteType) -> Note:
+    """Get a note by ID."""
+    if note_id != 1:
+        raise NotFoundError('Note does not exist')
+    return note
+
+
+def get_notes() -> Notes:
+    """Get a list of notes."""
+    return [note]
+
+
+def create_note(body: Body, done: Done=False) -> Note:
+    """Create a new note."""
+    return {'note_id': 2,
+            'body': body,
+            'done': done}
+
+
+def update_note(note_id: NoteId, body: Body=None, done: Done=None) -> Note:
+    """Update an existing note."""
+    if note_id != 1:
+        raise NotFoundError('Note does not exist')
+    new_note = note.copy()
+    if body is not None:
+        new_note['body'] = body
+    if done is not None:
+        new_note['done'] = done
+    return new_note
+
+
+def delete_note(note_id: NoteId):
+    """Delete an existing note."""
+    if note_id != 1:
+        raise NotFoundError('Note does not exist')
+
+
+def status() -> Status:
+    return 'Notes API v1.0.0'
+
+
+# -- mark-routes
+
+routes = (
+    Route('/', methods=(
+        get(status),), heading='API Status'),
+    Route('/note/', methods=(
+        get(get_notes, title='Retrieve List'),
+        post(create_note)), handler_name='NoteListHandler', heading='Notes (v1)'
+    ),
+    Route('/note/<int:note_id>/', methods=(
+        delete(delete_note),
+        get(get_note),
+        put(update_note)), heading='Notes (v1)'
+    ),
+    Route('/example/list-obj/', methods=(
+        get(example_array_and_object),), heading='Z'
+    ),
+)
+
+# -- mark-app
+
+app = Flask('Doctor example')
+
+api = Api(app)
+for route, resource in create_routes(routes):
+    api.add_resource(resource, route)
+
+if __name__ == '__main__':
+    app.run(debug=True)
+
+# -- mark-end

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -29,7 +29,7 @@ def get_item(item_id: ItemId, include_deleted: IncludeDeleted=False) -> Item:
     return {'item_id': 1}
 
 
-def create_item(item: Item, colors: Colors) -> Item:
+def create_item(item: Item, colors: Colors, optional_id: ItemId=None) -> Item:
     return {'item_id': 1}
 
 
@@ -58,18 +58,25 @@ def mock_post_logic():
     return mock_logic
 
 
-def test_handle_http_with_json(mock_request, mock_get_logic):
+def test_handle_http_with_json(mock_request, mock_post_logic):
     mock_request.method = 'POST'
     mock_request.content_type = 'application/json; charset=UTF8'
     mock_request.mimetype = 'application/json'
-    mock_request.json = {'item_id': 1, 'include_deleted': True}
+    mock_request.json = {
+        'item': {
+            'item_id': 1,
+        },
+        'colors': ['blue'],
+        'optional_id': None,
+    }
     mock_handler = mock.Mock()
 
-    actual = handle_http(mock_handler, (), {}, mock_get_logic)
+    actual = handle_http(mock_handler, (), {}, mock_post_logic)
     assert actual == ({'item_id': 1}, 201)
 
-    expected_call = mock.call(item_id=1, include_deleted=True)
-    assert expected_call == mock_get_logic.call_args
+    expected_call = mock.call(
+        item={'item_id': 1}, colors=['blue'], optional_id=None)
+    assert expected_call == mock_post_logic.call_args
 
 
 def test_handle_http_object_array_types(mock_request, mock_post_logic):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -101,6 +101,7 @@ class TestUtils(TestCase):
 
     @mock.patch('doctor.utils.logging')
     def test_add_param_annotations_duplicate_param(self, mock_logging):
+        delattr(get_foo, '_doctor_signature')
         new_params = [
             # name param is already in `get_foo` signature
             RequestParamAnnotation('name', Name, required=True),

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -99,6 +99,50 @@ class TestUtils(TestCase):
         is_deleted = actual._doctor_signature.parameters['is_deleted']
         assert expected == is_deleted
 
+    def test_add_param_annotations_mutliple_calls(self):
+        """
+        This test verifies if we call this function multiple times with
+        the same logic function that it doesn't squash parameters added
+        from the previous call.  This is a regression test.
+        """
+        delattr(get_foo, '_doctor_signature')
+        new_params = [
+            RequestParamAnnotation('auth', Auth, required=True),
+        ]
+        actual = add_param_annotations(get_foo, new_params)
+        expected_params = Params(
+            all=['name', 'age', 'is_alive', 'auth'],
+            logic=['name', 'age', 'is_alive'],
+            required=['name', 'age', 'auth'],
+            optional=['is_alive']
+        )
+        assert expected_params == actual._doctor_params
+
+        # verify `auth` added to the doctor_signature.
+        expected = Parameter('auth', Parameter.KEYWORD_ONLY,
+                             default=Parameter.empty, annotation=Auth)
+        auth = actual._doctor_signature.parameters['auth']
+        assert expected == auth
+
+        # Now call again adding the is_deleted param.  It should add to and
+        # not replace the auth param we added previously.
+        new_params = [
+            RequestParamAnnotation('is_deleted', IsDeleted)
+        ]
+        actual = add_param_annotations(get_foo, new_params)
+        expected_params = Params(
+            all=['name', 'age', 'is_alive', 'auth', 'is_deleted'],
+            logic=['name', 'age', 'is_alive'],
+            required=['name', 'age', 'auth'],
+            optional=['is_alive', 'is_deleted']
+        )
+        assert expected_params == actual._doctor_params
+        # verify `is_deleted` added to the doctor signature.
+        expected = Parameter('is_deleted', Parameter.KEYWORD_ONLY,
+                             default=None, annotation=IsDeleted)
+        is_deleted = actual._doctor_signature.parameters['is_deleted']
+        assert expected == is_deleted
+
     @mock.patch('doctor.utils.logging')
     def test_add_param_annotations_duplicate_param(self, mock_logging):
         delattr(get_foo, '_doctor_signature')

--- a/test/types.py
+++ b/test/types.py
@@ -9,7 +9,8 @@ Auth = string('auth token', example='testtoken')
 Color = enum('Color', enum=['blue', 'green'], example='blue')
 Colors = array('colors', items=Color, example=['green'])
 ExampleArray = array('ex description e', items=Auth, example=['ex', 'array'])
-ExampleObject = new_type(Object, 'ex description f', properties={'str': Auth},
+ExampleObject = new_type(Object, description='ex description f',
+                         properties={'str': Auth},
                          additional_properties=False, example={'str': 'ex str'})
 ExampleObjects = array(
     'ex objects', items=ExampleObject, example=[{'str': 'e'}])
@@ -17,8 +18,8 @@ Foo = string('foo', example='foo')
 FooId = integer('foo id', example=1)
 Foos = array('foos', items=Foo, example=['foo'])
 IsAlive = boolean('Is alive?', example=True)
-ItemId = integer('item id', minimum=1, example=1)
-Item = new_type(Object, 'item', properties={'item_id': ItemId},
+ItemId = integer('item id', minimum=1, example=1, nullable=True)
+Item = new_type(Object, description='item', properties={'item_id': ItemId},
                 additional_properties=False, required=['item_id'],
                 example={'item_id': 1})
 IncludeDeleted = boolean('indicates if deleted items should be included.',


### PR DESCRIPTION
This PR fixes a few bugs I encountered when integrating this into an existing doctor supported api.

- Updated `handle_http` to parse query and form parameters from strings to
  their expected type before we do validation on them.
- Fixed issue where if multiple decorators were used on a logic function
  and each one added param annotations the outer most decorator would
  erase any param annotations added from the previous decorator.
- Added a `nullable` attribute to all types to signify that `None` is a valid value for the type, in addition to it's native type.