### PR TITLE
Feature/request param name

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -41,6 +41,10 @@ Attributes
 * :attr:`~doctor.types.String.min_length` - The minimum length of the string.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 * :attr:`~doctor.types.String.pattern` - A regex pattern the string should
   match anywhere whitin it.  Uses `re.search`.
 * :attr:`~doctor.types.String.trim_whitespace` - If `True` the string will be
@@ -85,6 +89,10 @@ Attributes
   a multiple of this value.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 
 Example
 #######
@@ -126,6 +134,10 @@ Attributes
   a multiple of this value.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 
 Example
 #######
@@ -165,6 +177,10 @@ Attributes
   example value will be generated for you.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 
 Example
 #######
@@ -193,6 +209,10 @@ Attributes
   example value will be generated for you.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 
 Example
 #######
@@ -225,6 +245,10 @@ Attributes
   example value will be generated for you.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 * :attr:`~doctor.types.Object.properties` - A dict containing a mapping of
   property name to expected type.
 * :attr:`~doctor.types.Object.required` - A list of required properties.
@@ -271,6 +295,10 @@ Attributes
   in the list.
 * :attr:`~doctor.types.SuperType.nullable` - Indicates if the value of this type
   is allowed to be None.
+* :attr:`~doctor.types.SuperType.param_name` - The name of the request parameter
+  that should map to your logic function annotated parameter.  If not specified
+  it expects the request parameter will be named the same as the logic function
+  parameter name.
 * :attr:`~doctor.types.Array.unique_items` - If `True`, items in the array
   should be unique from one another.
 

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover
 from .constants import HTTP_METHODS_WITH_JSON_BODY
 from .errors import (ForbiddenError, ImmutableError, InvalidValueError,
                      NotFoundError, TypeSystemError, UnauthorizedError)
-from .parsers import parse_form_and_query_params
+from .parsers import map_param_names, parse_form_and_query_params
 from .response import Response
 from .routing import create_routes as doctor_create_routes
 from .routing import Route
@@ -113,7 +113,8 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
                 request.method in HTTP_METHODS_WITH_JSON_BODY):
             # This is a proper typed JSON request. The parameters will be
             # encoded into the request body as a JSON blob.
-            request_params = request.json
+            request_params = map_param_names(
+                request.json, logic._doctor_signature.parameters)
         else:
             # Try to parse things from normal HTTP parameters
             request_params = parse_form_and_query_params(

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -144,7 +144,7 @@ def parse_value(value, allowed_types, name='value'):
                      (name, ', '.join(allowed_types)))
 
 
-def parse_json(value, sig_params=None):
+def parse_json(value: str, sig_params: List[inspect.Parameter] = None) -> dict:
     """Parse a value as JSON.
 
     This is just a wrapper around json.loads which re-raises any errors as a
@@ -176,7 +176,8 @@ _native_type_to_json = {
 }
 
 
-def map_param_names(req_params: dict, sig_params: List[inspect.Parameter]):
+def map_param_names(
+        req_params: dict, sig_params: List[inspect.Parameter]) -> dict:
     """Maps request param names to match logic function param names.
 
     If a doctor type defined a `param_name` attribute for the name of the

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -203,7 +203,8 @@ def map_param_names(req_params: dict, sig_params: List[inspect.Parameter]):
     for k, param in sig_params.items():
         param_name = getattr(param.annotation, 'param_name', None)
         key = k if param_name is None else param_name
-        new_request_params[k] = req_params.get(key)
+        if key in req_params:
+            new_request_params[k] = req_params[key]
     return new_request_params
 
 

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -3,7 +3,9 @@ This is a collection of functions used to convert untyped param strings into
 their appropriate JSON schema types.
 """
 
+import inspect
 import logging
+from typing import List
 
 import simplejson as json
 
@@ -142,21 +144,26 @@ def parse_value(value, allowed_types, name='value'):
                      (name, ', '.join(allowed_types)))
 
 
-def parse_json(value):
+def parse_json(value, sig_params=None):
     """Parse a value as JSON.
 
     This is just a wrapper around json.loads which re-raises any errors as a
     ParseError instead.
 
     :param str value: JSON string.
+    :param dict sig_params: The logic function's signature parameters.
     :returns: the parsed JSON value
     """
     try:
-        return json.loads(value)
+        loaded = json.loads(value)
     except Exception as e:
         message = 'Error parsing JSON: %s' % e
         logging.debug(message, exc_info=e)
         raise ParseError(message)
+
+    if sig_params is not None:
+        return map_param_names(loaded, sig_params)
+    return loaded
 
 
 _native_type_to_json = {
@@ -167,6 +174,37 @@ _native_type_to_json = {
     float: 'number',
     str: 'string'
 }
+
+
+def map_param_names(req_params: dict, sig_params: List[inspect.Parameter]):
+    """Maps request param names to match logic function param names.
+
+    If a doctor type defined a `param_name` attribute for the name of the
+    parameter in the request, we should use that as the key when looking up
+    the value for the request parameter.
+
+    When we declare a type we can specify what the parameter name
+    should be in the request that the annotated type should get mapped to.
+
+    >>> from doctor.types import number
+    >>> Latitude = number('The latitude', param_name='location.lat')
+    >>> def my_logic(lat: Latitude): pass
+    >>> request_params = {'location.lat': 45.2342343}
+
+    In the above example doctor knows to pass the value at key `location.lat`
+    to the logic function variable named `lat` since it's annotated by the
+    `Latitude` type which specifies what the param_name is on the request.
+
+    :param dict req_params: The parameters specified in the request.
+    :param dict sig_params: The logic function's signature parameters.
+    :returns: A dict of re-mapped params.
+    """
+    new_request_params = {}
+    for k, param in sig_params.items():
+        param_name = getattr(param.annotation, 'param_name', None)
+        key = k if param_name is None else param_name
+        new_request_params[k] = req_params.get(key)
+    return new_request_params
 
 
 def parse_form_and_query_params(req_params, sig_params):

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -65,6 +65,10 @@ class SuperType(object):
     #: Indicates if the value of this type is allowed to be None.
     nullable = False  # type: bool
 
+    #: An optional name of where to find the request parameter if it does not
+    #: match the variable name in your logic function.
+    param_name = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.description is None:

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -83,7 +83,8 @@ def test_handle_http_with_json(mock_request, mock_post_logic):
     assert actual == ({'item_id': 1}, 201)
 
     expected_call = mock.call(
-        item={'item_id': 1}, colors=['blue'], optional_id=None)
+        item={'item_id': 1}, colors=['blue'], optional_id=None,
+        lat=45.2342343)
     assert expected_call == mock_post_logic.call_args
 
 

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -16,7 +16,7 @@ from doctor.response import Response
 from doctor.utils import (
     add_param_annotations, get_params_from_func, Params, RequestParamAnnotation)
 
-from .types import Auth, Colors, Item, ItemId, IncludeDeleted
+from .types import Auth, Colors, Item, ItemId, IncludeDeleted, Latitude
 from .utils import add_doctor_attrs
 
 
@@ -31,11 +31,12 @@ def check_auth(func):
     return _wrapper
 
 
-def get_item(item_id: ItemId, include_deleted: IncludeDeleted=False) -> Item:
+def get_item(item_id: ItemId, include_deleted: IncludeDeleted = False) -> Item:
     return {'item_id': 1}
 
 
-def create_item(item: Item, colors: Colors, optional_id: ItemId=None) -> Item:
+def create_item(item: Item, colors: Colors, optional_id: ItemId = None,
+                lat: Latitude = None) -> Item:
     return {'item_id': 1}
 
 
@@ -74,6 +75,7 @@ def test_handle_http_with_json(mock_request, mock_post_logic):
         },
         'colors': ['blue'],
         'optional_id': None,
+        'location.lat': 45.2342343,
     }
     mock_handler = mock.Mock()
 

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -5,10 +5,11 @@ import inspect
 import pytest
 
 from doctor.errors import ParseError, TypeSystemError
-from doctor.parsers import parse_form_and_query_params, parse_json, parse_value
+from doctor.parsers import (
+    map_param_names, parse_form_and_query_params, parse_json, parse_value)
 
 from .base import TestCase
-from .types import Age, Color, IsDeleted
+from .types import Age, Auth, Color, IsDeleted, Latitude, Longitude, OptIn
 
 
 def logic(age: Age, color: Color, is_deleted: IsDeleted=False):
@@ -110,3 +111,24 @@ class TestParsers(TestCase):
             'age': 'value must be a valid type (integer)',
             'is_deleted': 'value must be a valid type (boolean)',
         } == exc.value.errors
+
+    def test_map_param_names(seilf):
+        def foo(lat: Latitude, lon: Longitude, opt_in: OptIn, auth: Auth):
+            pass
+
+        sig = inspect.signature(foo)
+        request_params = {
+            'auth': 'auth',
+            'location.lat': 45.12345,
+            'locationLon': -122.12345,
+            'opt-in': True,
+        }
+        actual = map_param_names(request_params, sig.parameters)
+
+        expected = {
+            'auth': 'auth',
+            'lat': 45.12345,
+            'lon': -122.12345,
+            'opt_in': True,
+        }
+        assert expected == actual

--- a/test/types.py
+++ b/test/types.py
@@ -1,7 +1,8 @@
 """
 This module contains custom types used by tests.
 """
-from doctor.types import array, boolean, enum, integer, new_type, number, string, Object
+from doctor.types import (
+    array, boolean, enum, integer, new_type, number, string, Object)
 
 
 Age = integer('age', minimum=1, maximum=120, example=34)
@@ -28,4 +29,8 @@ IsDeleted = boolean('Indicates if the item should be marked as deleted',
                     example=False)
 Latitude = number('The latitude.', example=44.322804,
                   param_name='location.lat', nullable=True)
+Longitude = number('the longitude.', example=-122.34232,
+                   param_name='locationLon', nullable=True)
 Name = string('name', min_length=1, example='John')
+OptIn = boolean('If the user has opted in to gps tracking.',
+                param_name='opt-in')

--- a/test/types.py
+++ b/test/types.py
@@ -1,7 +1,7 @@
 """
 This module contains custom types used by tests.
 """
-from doctor.types import array, boolean, enum, integer, new_type, string, Object
+from doctor.types import array, boolean, enum, integer, new_type, number, string, Object
 
 
 Age = integer('age', minimum=1, maximum=120, example=34)
@@ -26,4 +26,6 @@ IncludeDeleted = boolean('indicates if deleted items should be included.',
                          example=False)
 IsDeleted = boolean('Indicates if the item should be marked as deleted',
                     example=False)
+Latitude = number('The latitude.', example=44.322804,
+                  param_name='location.lat', nullable=True)
 Name = string('name', min_length=1, example='John')


### PR DESCRIPTION
This adds the ability to specify what request parameter the annotated logic function parameter should be mapped to.  This is for cases where your parameter names do not translate to valid python variable names (e.g. `location.lat`) or don't conform to pep8 (e.g. `locationLat`).

For example:

```python
from doctor.types import Number

Latitude = number('The latitude', example=42.23433, param_name='location.lat')

def logic(lat: Latitude):
    pass
```

The above code will map the request variable at `location.lat` to the `lat` param in the logic function.