### PR TITLE
Fixed AttributeError bug.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Fixed an `AttributeError` when a logic function contained a parameter in it's
+  signature that was not annotated by a doctor type and a request parameter
+  in a form or query request also contained a variable that matched it's name.
+
 v3.8.0 (2018-06-21)
 -------------------
 

--- a/doctor/parsers.py
+++ b/doctor/parsers.py
@@ -221,10 +221,16 @@ def parse_form_and_query_params(req_params, sig_params):
     :returns: a dict of params parsed from the input dict.
     :raises TypeSystemError: If there are errors parsing values.
     """
+    # Importing here to prevent circular dependencies.
+    from doctor.types import SuperType
     errors = {}
     parsed_params = {}
     for param, value in req_params.items():
+        # Skip request variables not in the function signature.
         if param not in sig_params:
+            continue
+        # Skip coercing parameters not annotated by a doctor type.
+        if not issubclass(sig_params[param].annotation, SuperType):
             continue
         native_type = sig_params[param].annotation.native_type
         json_type = [_native_type_to_json[native_type]]

--- a/test/test_parsers.py
+++ b/test/test_parsers.py
@@ -112,6 +112,25 @@ class TestParsers(TestCase):
             'is_deleted': 'value must be a valid type (boolean)',
         } == exc.value.errors
 
+    def test_parse_form_and_query_params_no_doctor_type_param_in_sig(self):
+        """
+        This is a regression test for when a logic function has a parameter
+        in it's signature that is not annotated by a doctor type and the name
+        of the parameter matches a parameter in the request variables.
+        Previously this would cause an AttributeError.
+        """
+        def logic(age: Age, use_cache: bool = False):
+            pass
+
+        sig = inspect.signature(logic)
+        params = {
+            'age': '22',
+            'use_cache': '1',
+        }
+        actual = parse_form_and_query_params(params, sig.parameters)
+        expected = {'age': 22}
+        assert expected == actual
+
     def test_map_param_names(seilf):
         def foo(lat: Latitude, lon: Longitude, opt_in: OptIn, auth: Auth):
             pass


### PR DESCRIPTION
This occurred when a logic function contained a parameter in it's
signature that was not annotated by a doctor type and a request parameter
in a form or query request also contained a variable that matched it's name.

See issue #97 