### PR TITLE
Fixed issue discovered while testing flask==1.0.2

### DIFF
--- a/doctor/routing.py
+++ b/doctor/routing.py
@@ -198,6 +198,7 @@ def create_routes(routes: Tuple[HTTPMethod], handle_http: Callable,
             handler_methods_and_properties = {
                 '__name__': handler_name,
                 '_doctor_heading': r.heading,
+                'methods': set([http_method.upper()]),
                 http_method: http_func,
             }
             if handler is None:
@@ -211,6 +212,6 @@ def create_routes(routes: Tuple[HTTPMethod], handle_http: Callable,
                 # need to add all the other http methods we are defining
                 # on the handler after it gets created by type.
                 if hasattr(handler, 'methods'):
-                    handler.methods.append(http_method.upper())
+                    handler.methods.add(http_method.upper())
         created_routes.append((r.route, handler))
     return created_routes


### PR DESCRIPTION
Discovered this when updating an api to flask==1.0.2.  See #99 

It looks like in [MethodViewType](https://github.com/pallets/flask/blob/0.12.2/flask/views.py#L107) the methods attribute was always a `set` if
methods was not provided.  Prior to v1.0.0 we were passing it in as a
`list` and the MethodView kept it that way instead of converting to a `set`.
With >= v1.0.0 methods will always be a `set`.  To make this work with
older versions and new versions, we now pass in methods initially as a
`set` and update the routing code to use `.add` instead of `.append` for the
methods of the handler.