### PR TITLE
Don't filter out request params not defined in a type object for routes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Don't filter out request parameters not defined in the type object for routes
+  that specify a `req_obj_type`.
+
 v3.8.2 (2018-07-02)
 -------------------
 

--- a/doctor/flask.py
+++ b/doctor/flask.py
@@ -123,9 +123,12 @@ def handle_http(handler: Resource, args: Tuple, kwargs: Dict, logic: Callable):
             request_params = parse_form_and_query_params(
                 request.values, logic._doctor_signature.parameters)
 
-        # Filter out any params not part of the logic signature.
-        all_params = logic._doctor_params.all
-        params = {k: v for k, v in request_params.items() if k in all_params}
+        params = request_params
+        # Only filter out additional params if a req_obj_type was not specified.
+        if not logic._doctor_req_obj_type:
+            # Filter out any params not part of the logic signature.
+            all_params = logic._doctor_params.all
+            params = {k: v for k, v in params.items() if k in all_params}
         params.update(**kwargs)
 
         # Check for required params


### PR DESCRIPTION
that specify a `req_obj_type`.

Addresses #104 