### PR TITLE
Added parser attribute to doctor types.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Added optional `parser` attribute to doctor types that allows the ability
+  to specify a callable to parse the request parameter before it gets validated.
+  See the documentation for more information.
+
 v3.9.0 (2018-07-13)
 -------------------
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -45,6 +45,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 * :attr:`~doctor.types.String.pattern` - A regex pattern the string should
   match anywhere whitin it.  Uses `re.search`.
 * :attr:`~doctor.types.String.trim_whitespace` - If `True` the string will be
@@ -93,6 +95,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 
 Example
 #######
@@ -138,6 +142,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 
 Example
 #######
@@ -181,6 +187,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 
 Example
 #######
@@ -213,6 +221,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 
 Example
 #######
@@ -249,6 +259,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 * :attr:`~doctor.types.Object.properties` - A dict containing a mapping of
   property name to expected type.
 * :attr:`~doctor.types.Object.required` - A list of required properties.
@@ -302,6 +314,8 @@ Attributes
   that should map to your logic function annotated parameter.  If not specified
   it expects the request parameter will be named the same as the logic function
   parameter name.
+* :attr:`~doctor.types.SuperType.parser` - An optional function to parse the request
+  parameter before it's passed to the type. :ref:`See custom type parser<custom-type-parser>`.
 * :attr:`~doctor.types.Array.unique_items` - If `True`, items in the array
   should be unique from one another.
 
@@ -495,6 +509,55 @@ Examples
 
     # Create a new type based on FirstName, but is allowed to be None
     NullableFirstName = new_type(FirstName, nullable=True)
+
+
+.. _custom-type-parser:
+
+Custom Type Parser
+------------------
+
+In some instances you don't have control over what data gets sent to an endpoint
+due to legacy integrations.  If you need the ability to transform a request
+parameter before it gets validated by the type, you can specify a custom
+:attr:`~doctor.types.SuperType.parser` attribute.  It's value should be a
+callable that accepts a value that is the request parameter and returns the parsed
+value.  The callable should raise a :class:`~doctor.errors.ParserError` if it
+fails to parse the value.
+
+.. code-block:: python
+
+   # types.py
+
+   from typing import List
+
+   from doctor.errors import ParserError
+   from doctor.types import array, string
+
+   def str_to_array(value: str) -> List[str]:
+      """Parses a comma separated value to an array.
+
+      Our request parameter is a str that looks like: `'item1,item2'`
+
+      >>> str_to_array('item1,item2')
+      ['item1', 'item2']
+
+      :param value: The value to parse, e.g. 'item1,item2'
+      :returns: A list of values.
+      """
+      # If your logic is more complex and the value can't be parsed, raise
+      # a `TypeError` in your function.
+      return value.split(',')
+
+   Item = string('An item.')
+   Items = array('An array of items.', items=Item, parser=str_to_array)
+
+   # logic.py
+
+   # HTTP POST /items items=item1%2Citem2
+   def create_items(items: Items):
+      # The comma separated string becomes a list of items when passed to the
+      # logic function.
+      print(items)  # ['item1', 'item2']
 
 .. _types-module-documentation:
 

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -69,6 +69,11 @@ class SuperType(object):
     #: match the variable name in your logic function.
     param_name = None
 
+    #: An optional callable to parse a request paramter before it gets validated
+    #: by a type.  It should accept a single value paramter and return the
+    #: parsed value.
+    parser = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.description is None:

--- a/doctor/utils/__init__.py
+++ b/doctor/utils/__init__.py
@@ -248,5 +248,5 @@ def get_valid_class_name(s: str) -> str:
     :returns: The updated string.
     """
     s = str(s).strip()
-    s = ''.join([w.title() for w in re.split('\W+|_', s)])
+    s = ''.join([w.title() for w in re.split(r'\W+|_', s)])
     return re.sub(r'[^\w|_]', '', s)

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,13 @@ exclude =
     .tox,
     docs/*
 max-line-length = 80
-# E251 unexpected spaces around keyword / parameter equals
-ignore = E251
+ignore = 
+    # E251 - Remove whitespace around parameter '=' sign.
+    E251,
+    # E252 - Missing whitespace around parameter equals.
+    E252,
+    # W504 - Fix line break after binary operator.
+    W504
 
 [tool:pytest]
 ingore =

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -199,7 +199,7 @@ def test_handle_http_missing_multiple_required_args(
 
     mock_handler = mock.Mock()
     with pytest.raises(HTTP400Exception,
-                       match="\['item', 'colors'\] are required."):
+                       match=r"\['item', 'colors'\] are required."):
         handle_http(mock_handler, (), {}, mock_post_logic)
 
 
@@ -249,7 +249,7 @@ def test_handle_http_invalid_param(mock_request, mock_get_logic):
     mock_request.values = {'item_id': 'string'}
     mock_handler = mock.Mock()
 
-    expected_msg = 'item_id - value must be a valid type \(integer, null\)'
+    expected_msg = r'item_id - value must be a valid type \(integer, null\)'
     with pytest.raises(HTTP400Exception, match=expected_msg):
         handle_http(mock_handler, (), {}, mock_get_logic)
 

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -309,7 +309,7 @@ class TestEnum(object):
         E('foo')
         E('bar')
         # not in choices
-        expected_msg = "Must be one of: \['foo', 'bar'\]"
+        expected_msg = r"Must be one of: \['foo', 'bar'\]"
         with pytest.raises(TypeSystemError, match=expected_msg):
             E('dog')
 

--- a/test/types.py
+++ b/test/types.py
@@ -5,6 +5,10 @@ from doctor.types import (
     array, boolean, enum, integer, new_type, number, string, Object)
 
 
+def parse_comma_separated_str(value):
+    return value.split(',')
+
+
 Age = integer('age', minimum=1, maximum=120, example=34)
 Auth = string('auth token', example='testtoken')
 Color = enum('Color', enum=['blue', 'green'], example='blue')
@@ -24,6 +28,8 @@ ExampleObjects = array(
 Foo = string('foo', example='foo')
 FooId = integer('foo id', example=1)
 Foos = array('foos', items=Foo, example=['foo'])
+FoosWithParser = array('foos with parser', items=Foo,
+                       parser=parse_comma_separated_str)
 IsAlive = boolean('Is alive?', example=True)
 ItemId = integer('item id', minimum=1, example=1, nullable=True)
 Item = new_type(Object, description='item', properties={'item_id': ItemId},


### PR DESCRIPTION
This allows the ability to specify a callable to parse a request param for the annotated variable before it get's validated. See #106 for more details.