### PR TITLE
Fixed bug in api docs generation introduced in the last release.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Fixed bug introducded in v3.10.1 when doctor attempted to generate api
+  documentation when an endpoint had a request parameter that was an array of
+  objects.
+
 v3.10.1 (2018-12-07)
 --------------------
 

--- a/doctor/docs/base.py
+++ b/doctor/docs/base.py
@@ -173,7 +173,7 @@ def get_array_items_description(item: Array) -> str:
             _enum = ' Must be one of: `{}`.'.format(
                 item.items.enum)
         elif issubclass(item.items, Object):
-            ref = get_object_reference(item)
+            ref = get_object_reference(item.items)
         desc = '  *Items must be*: {description}{enum}{ref}'.format(
             description=desc, enum=_enum, ref=ref)
     return desc

--- a/test/test_docs_base.py
+++ b/test/test_docs_base.py
@@ -431,3 +431,8 @@ class TestDocsBaseHarness(TestCase):
         expected = (" *Item 0 must be*: age *Item 1 must be*: ex description "
                     "f See :ref:`resource-example-object`.")
         assert expected == actual
+
+        actual = base.get_array_items_description(ExampleObjects)
+        expected = ('  *Items must be*: ex description f See '
+                    ':ref:`resource-example-object`.')
+        assert expected == actual


### PR DESCRIPTION
If a response or request param for a route had an array of objects we
would encounter an AttributeError.  Fixes #111 