### PR TITLE
Multiple bugfixes for UnionType.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Fixed UnionType types from not getting passed to logic functions.
+* Fixed UnionType types from not getting documented in api docs.
+* Fixed bug with native_type for UnionType which could cause an error parsing
+  the value, even if it conformed to one of the n types defined.
+
 v3.10.2 (2018-12-10)
 --------------------
 

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -68,6 +68,13 @@ class TestUnionType(object):
         # Should be the first native_type in the types attribute.
         assert Item.native_type == bool
 
+        # After instantiating with a value, it should update the native_type
+        # to match the value.
+        assert 'S' == Item('S')
+        assert Item.native_type == str
+        assert Item(True)
+        assert Item.native_type == bool
+
 
 class TestString(object):
 

--- a/test/types.py
+++ b/test/types.py
@@ -61,4 +61,10 @@ class FooInstance(Object):
 
 
 class AgeOrColor(UnionType):
+    description = 'age or color'
     types = [Age, Color]
+
+
+class ColorsOrObject(UnionType):
+    description = 'Colors or an example object.'
+    types = [Colors, ExampleObject]


### PR DESCRIPTION
Addresses bugs in #116 .

* Fixed UnionType types from not getting passed to logic functions.
* Fixed UnionType types from not getting documented in api docs.
* Fixed bug with native_type for UnionType which could cause an error parsing
  the value, even if it conformed to one of the n types defined.