### PR TITLE
Document default values for optional request paramters.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Document default values for optional request params by inspecting
+  the logic function signature.
+
 v3.10.3 (2018-12-12)
 --------------------
 

--- a/test/test_docs_base.py
+++ b/test/test_docs_base.py
@@ -83,8 +83,9 @@ class TestDocsBase(TestCase):
         assert result == [
             ':>json str auth: **Required**.  auth token',
             ':>json bool is_alive: **Required**.  Is alive?',
-            ":>json str color: Color Must be one of: `['blue', 'green']`.",
-            ':>json str name: name']
+            (":>json str color: Color Must be one of: `['blue', 'green']`. "
+             "(Defaults to `blue`) "),
+            ':>json str name: name (Defaults to `None`) ']
 
     def test_get_json_object_lines_for_request(self):
         """
@@ -108,7 +109,7 @@ class TestDocsBase(TestCase):
             ':param int age: **Required**.  age',
             ':>json str auth: **Required**.  auth token',
             (':>json bool is_deleted: Indicates if the item should be marked '
-             'as deleted'),
+             'as deleted (Defaults to `True`) '),
         ]
 
     def test_get_json_object_lines_object_response(self):


### PR DESCRIPTION
By inspecting the logic function we can document default values for optional parameters.  Addresses #113 

Example:

```python
def create_note(body: t.Body, done: t.Done = False):
    pass
```

![screen shot 2018-12-19 at 2 52 55 pm](https://user-images.githubusercontent.com/109865/50253077-ddf3c500-039d-11e9-8b76-abf84de1b0fd.png)

