### PR TITLE
Fixed bug where you could not provide description when using new_type.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Fixed bug where you could not specify a custom description when using
+  the `new_type` type function when the type provided had it's own description
+  attribute.
+
 v3.11.0 (2019-01-04)
 --------------------
 

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -878,10 +878,9 @@ def array(description, **kwargs) -> typing.Type:
 def new_type(cls, **kwargs) -> typing.Type:
     """Create a user defined type.
 
-    :param description: A description of the type.
     :param kwargs: Can include any attribute defined in
         the provided user defined type.
     """
-    if getattr(cls, 'description', None):
+    if 'description' not in kwargs and getattr(cls, 'description', None):
         kwargs['description'] = cls.description
     return type(cls.__name__, (cls,), kwargs)

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -710,3 +710,9 @@ def test_new_type_uses_parent_description():
     assert 'A string' == N.description
     assert S.nullable is False
     assert N.nullable is True
+
+
+def test_new_type_allows_custom_description():
+    S = string('A string', example='Foo')
+    N = new_type(S, description='A different description')
+    assert 'A different description' == N.description


### PR DESCRIPTION
When calling new_type(), if the the type passed to it had it's own
description attribute, it was not possible to override it.  Addressed #120 