### PR TITLE
Avoid creating duplicate object reference links in docs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Fixed a bug that caused object reference links to be duplicated when documenting
+  a request param or response property that was a list of dicts.
+
 v3.12.2 (2019-02-04)
 --------------------
 

--- a/doctor/docs/base.py
+++ b/doctor/docs/base.py
@@ -273,7 +273,11 @@ def get_json_object_lines(annotation: ResourceAnnotation,
         # Document type(s) for an array's items.
         if (issubclass(annotated_type, Array) and
                 annotated_type.items is not None):
-            description += get_array_items_description(annotated_type)
+            array_description = get_array_items_description(annotated_type)
+            # Prevents creating a duplicate object reference link in the docs.
+            if obj_ref in array_description:
+                obj_ref = ''
+            description += array_description
 
         # Document any default value.
         default = ''


### PR DESCRIPTION
Fixes the duplicate object reference link in the docs like below:

![Screen Shot 2019-04-22 at 9 52 38 AM](https://user-images.githubusercontent.com/109865/56512908-96b14880-64e5-11e9-8108-b94137b9614e.png)
