### PR TITLE
Added case_insensitive attribute for Enum types.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Release History
 Next release (in development)
 -----------------------------
 
+* Added case_insensitive option to Enum type.
+
 v3.12.3 (2019-04-22)
 --------------------
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -212,6 +212,8 @@ Attributes
 * :attr:`~doctor.types.SuperType.description` - A human readable description
   of what the type represents.  This will be used when generating documentation.
 * :attr:`~doctor.types.Enum.enum` - A list of `str` containing valid values.
+* :attr:`~doctor.types.Enum.case_insensitive` - A boolean indicating if the
+  values of the enum attribute are case insensitive or not.
 * :attr:`~doctor.types.SuperType.example` - An example value to send to the
   endpoint when generating API documentation.  This is optional and a default
   example value will be generated for you.

--- a/doctor/types.py
+++ b/doctor/types.py
@@ -423,11 +423,16 @@ class Enum(SuperType, str):
     }
     #: A list of valid values.
     enum = []  # type: typing.List[str]
+    #: Indicates if the values of the enum are case insensitive or not.
+    case_insensitive = False
 
     def __new__(cls, value: typing.Union[None, str]):
         if cls.nullable and value is None:
             return None
 
+        if cls.case_insensitive:
+            cls.enum = [v.lower() for v in cls.enum]
+            value = value.lower()
         if value not in cls.enum:
             raise TypeSystemError(cls=cls, code='invalid')
 

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -383,6 +383,16 @@ class TestEnum(object):
         with pytest.raises(TypeSystemError, match='Value must be one'):
             E('two')
 
+    def test_case_insensitive(self):
+        E = enum('choices', enum=['foo'], case_insensitive=True)
+        E('foo')
+        E('FOO')
+        E('fOO')
+        E('foO')
+        expected_msg = r"Must be one of: \['foo'\]"
+        with pytest.raises(TypeSystemError, match=expected_msg):
+            E('dog')
+
     def test_nullalbe(self):
         E = enum('choices', enum=['foo'], nullable=True)
         assert E(None) is None


### PR DESCRIPTION
Adds the ability to specify the enum should be case insensitive so we don't need duplicate values for lower/upper case.

```python
>>> from doctor.types import enum
>>> Frequency = enum('The frequency of something.', enum=['daily', 'weekly'], case_insensitive=True)
>>> Frequency('daily')
>>> Frequency('DAILY')
>>> Frequency('DailY')
>>> Frequency('bad')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/doctor/types.py", line 432, in __new__
    raise TypeSystemError(cls=cls, code='invalid')
doctor.errors.TypeSystemError: Must be one of: ['daily', 'weekly']
```